### PR TITLE
Added TT to query in stepslib

### DIFF
--- a/backup/moodle2/restore_turnitintooltwo_stepslib.php
+++ b/backup/moodle2/restore_turnitintooltwo_stepslib.php
@@ -121,7 +121,7 @@ class restore_turnitintooltwo_activity_structure_step extends restore_activity_s
         if (!$tiiuser = $DB->get_record('turnitintooltwo_users', array('userid' => $data->ownerid))) {
             $DB->insert_record('turnitintooltwo_users',$tiiowner);
         }
-        if (!$DB->get_records('turnitintooltwo_courses', array('courseid' => $data->courseid))) {
+        if (!$DB->get_records('turnitintooltwo_courses', array('courseid' => $data->courseid, 'course_type' => 'TT'))) {
             $data->course_type = 'TT';
             $newitemid = $DB->insert_record('turnitintooltwo_courses', $data);
             $this->set_mapping('turnitintooltwo_courses', $oldid, $newitemid);


### PR DESCRIPTION
Added parameter requirement to search for course_type = 'TT' to fix bug where restore was grabbing the wrong classes.