### PR TITLE
Improve Nonce generation function to allow for concurrent processes

### DIFF
--- a/sdk/oauthsimple.class.php
+++ b/sdk/oauthsimple.class.php
@@ -368,9 +368,10 @@ class OAuthSimple {
         $result = '';
         $cLength = strlen($this->_nonce_chars);
         for ($i = 0; $i < $length; $i++) {
-            $rnum = rand(0, $cLength);
+            $rnum = mt_rand(0, $cLength);
             $result .= substr($this->_nonce_chars, $rnum, 1);
         }
+        $result .= getmypid();
         $this->_parameters['oauth_nonce'] = sha1($result);
 
         return $result;


### PR DESCRIPTION
Hello,

This is a small change to improve the way nonces are generated. In our set up, we have a queueing system to process submissions to Turnitin with many queue workers processing jobs and sometimes this queue workers might try to submit something to Turnitin simultaneously. As a result we were getting several "nonce already used" errors.

My change makes the _getNonce function more robust so that identical nonces are no longer generated by concurrent processes and it also increases the randomness of the nonce.

It has been working on our set up for a few months now without issues and I believe it doesn't affect the existing functionality in non-concurrent scenarios.