### PR TITLE
Send submission receipts from noreply instead of admin

### DIFF
--- a/classes/digitalreceipt/receipt_message.php
+++ b/classes/digitalreceipt/receipt_message.php
@@ -9,13 +9,12 @@ class receipt_message {
      * @return void
      */
     public function send_message($userid, $message) {
-
         $subject = get_string('digital_receipt_subject', 'turnitintooltwo');
 
         $eventdata = new stdClass();
         $eventdata->component         = 'mod_turnitintooltwo'; //your component name
         $eventdata->name              = 'submission'; //this is the message name from messages.php
-        $eventdata->userfrom          = get_admin();
+        $eventdata->userfrom          = $CFG->noreplyaddress;
         $eventdata->userto            = $userid;
         $eventdata->subject           = $subject;
         $eventdata->fullmessage       = $message;


### PR DESCRIPTION
Modified object variable in `receipt_message->send_message` to replace the site administrator address with the site default noreply address.