### PR TITLE
Changing default for missing first and last name to be N/A.

### DIFF
--- a/turnitintooltwo_user.class.php
+++ b/turnitintooltwo_user.class.php
@@ -93,9 +93,9 @@ class turnitintooltwo_user {
 
         // Set a default for first and last name in the event they are empty.
         $firstname = trim($this->firstname);
-        $this->firstname = (empty($firstname)) ? "Moodle" : $firstname;
+        $this->firstname = (empty($firstname)) ? "N/A" : $firstname;
         $lastname = trim($this->lastname);
-        $this->lastname = (empty($lastname)) ? "User ".$this->id : $lastname;
+        $this->lastname = (empty($lastname)) ? "N/A" : $lastname;
 
         $this->email = trim(html_entity_decode($user->email));
         $this->username = $user->username;


### PR DESCRIPTION
Related to:

https://github.com/turnitin/moodle-mod_turnitintooltwo/pull/63

And

https://github.com/turnitin/moodle-mod_turnitintool/pull/14

At our university we feel that having a default of N/A is better than the current default of Moodle and User <id> for first and last name respectively. It is simpler and more understandable of what is happening.