### PR TITLE
Fixed teachers receiving submission notifications.

### DIFF
--- a/classes/digitalreceipt/instructor_message.php
+++ b/classes/digitalreceipt/instructor_message.php
@@ -39,7 +39,7 @@ class instructor_message {
 
         $eventdata = new stdClass();
         $eventdata->component         = 'mod_turnitintooltwo'; //your component name
-        $eventdata->name              = 'submission'; //this is the message name from messages.php
+        $eventdata->name              = 'notify_instructor_of_submission'; //this is the message name from messages.php
         $eventdata->userfrom          = \core_user::get_noreply_user();
         $eventdata->subject           = $subject;
         $eventdata->fullmessage       = $message;


### PR DESCRIPTION
Fixed a bug where messages for 'Turnitin Assignment Instructor Digital Receipt notifications' was sent as 'Turnitin Assignment Digital Receipt notifications'. This cause disabling the setting of 'Turnitin Assignment Instructor Digital Receipt notifications' have no effect.
It is related to issue #148 