### PR TITLE
Revert "Fixed teachers receiving submission notifications."

### DIFF
--- a/classes/digitalreceipt/instructor_message.php
+++ b/classes/digitalreceipt/instructor_message.php
@@ -39,7 +39,7 @@ class instructor_message {
 
         $eventdata = new stdClass();
         $eventdata->component         = 'mod_turnitintooltwo'; //your component name
-        $eventdata->name              = 'notify_instructor_of_submission'; //this is the message name from messages.php
+        $eventdata->name              = 'submission'; //this is the message name from messages.php
         $eventdata->userfrom          = \core_user::get_noreply_user();
         $eventdata->subject           = $subject;
         $eventdata->fullmessage       = $message;


### PR DESCRIPTION
Reverts turnitin/moodle-mod_turnitintooltwo#156

subsequent testing shows that this disables all receipt notifications of this nature.