### PR TITLE
Submission inbox list inactive students

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1461,8 +1461,12 @@ class turnitintooltwo_assignment {
      * @return array of course users or empty array if none
      */
     public function get_moodle_course_users($cm) {
-        $courseusers = get_users_by_capability(context_module::instance($cm->id),
-                                'mod/turnitintooltwo:submit', '', 'u.lastname, u.firstname');
+        $context = context_module::instance($cm->id);
+        $courseusers = get_users_by_capability($context, 'mod/turnitintooltwo:submit', '', 'u.lastname, u.firstname');
+        $suser = get_suspended_userids($context);
+        foreach ($suser as $k => $v) {
+            unset($courseusers[$k]);
+        }
 
         return (!is_array($courseusers)) ? array() : $courseusers;
     }
@@ -1868,6 +1872,10 @@ class turnitintooltwo_assignment {
         if ($istutor && $userid == 0) {
             $users = get_users_by_capability($context, 'mod/turnitintooltwo:submit', 'u.id, u.firstname, u.lastname',
                                                 '', '', '', groups_get_activity_group($cm), '');
+            $suser = get_suspended_userids($context);
+            foreach ($suser as $k => $v) {
+                unset($users[$k]);
+            }
             $users = (!$users) ? array() : $users;
         } else if ($istutor) {
             $user = $DB->get_record('user', array('id' => $userid));


### PR DESCRIPTION
- fix to exclude inactive students without submission in submission inbox and as a result, inactive students with submission are marked as "Non Enroled student"
- fix to exclude inactive students when click "Enrol All Students"