### PR TITLE
Add debugging to migration tool

### DIFF
--- a/logs/migrationtool/debug/.gitignore
+++ b/logs/migrationtool/debug/.gitignore
@@ -2,4 +2,3 @@
 *
 # Except this file
 !.gitignore
-!/debug


### PR DESCRIPTION
Adds a debugging log that is created during a run of the migration tool. This helps us determine which part of the tool is being slow. I didn't place the strings into the language string file as this is just for us and we may decide to remove it before releasing the tool.