### PR TITLE
INT-6237 - Move gradebook updates to the cron

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -835,7 +835,7 @@ switch ($action) {
             $doOnce = 0;
         }
         if (!$trial) {
-            fputs($debug, date('H:i:s')." - Begin Ajax call with the following parameters:\r\nStart: ".$start."\r\nProcess at Once: ".$processAtOnce."\r\nIteration: ".$iteration."\r\nTrial: ".$trial."\r\nTotal To Migrate: ".$totalToMigrate."\r\nETD: ".$etd."\r\n");
+            fputs($debug, date('H:i:s')." - Begin Ajax call with the following parameters: Start: ".$start." Process at Once: ".$processAtOnce." Iteration: ".$iteration." Trial: ".$trial." Total To Migrate: ".$totalToMigrate." ETD: ".$etd."\r\n");
         }
 
         // Initialise the CSV log.
@@ -1012,19 +1012,13 @@ switch ($action) {
                             foreach ($v1_part_submissions as $v1_part_submission) {
                                 $v1_part_submission->turnitintooltwoid = $turnitintooltwoid;
                                 $v1_part_submission->submission_part = $v2_part_id;
+                                $v1_part_submission->migration_gradebook = 1;
                                 unset($v1_assignment_submissions->turnitintoolid);
                                 unset($v1_part_submission->id);
 
                                 $turnitintooltwo_submissionid = $DB->insert_record("turnitintooltwo_submissions", $v1_part_submission);
-
-                                // Get the V2 part and update grade book.
-                                $gradebook_start = round(microtime(true) * 1000);
-                                $v2_part_submission = $DB->get_record("turnitintooltwo_submissions", array("id" => $turnitintooltwo_submissionid));
-                                turnitintooltwo_submission::update_gradebook($v2_part_submission, $turnitintooltwoassignment);
-                                $gradebook_end = round(microtime(true) * 1000);
-                                $total_gradebook_time += ($gradebook_end - $gradebook_start);
                             }
-                            fputs($debug, "+".calcRunTime($startTime)." seconds - Finished submission migration for part ".$v1_part->tiiassignid."\r\n                  Time spent updating gradebook: ".($total_gradebook_time/1000)." seconds.\r\n");
+                            fputs($debug, "+".calcRunTime($startTime)." seconds - Finished submission migration for part ".$v1_part->tiiassignid."\r\n                  Time spent updating gradebook: 0 seconds.\r\n");
                         }
                         if (!$trial) {
                             fputs($debug, "+".calcRunTime($startTime)." seconds - Finished part migration for part name '".$v1_part->partname."' (TII: ".$v1_part->tiiassignid.") (Moodle: ".$v1_part_id.")\r\n");
@@ -1032,7 +1026,7 @@ switch ($action) {
                     }
 
                     if (!$trial) {
-                        // Update the grades for this assignment.
+                        // Create entry in gradebook for this assignment.
                         turnitintooltwo_grade_item_update($turnitintooltwoassignment->turnitintooltwo);
                         fputs($debug, "+".calcRunTime($startTime)." seconds - Finished migration for assignment: '".$v1_assignment->name."' (Moodle ID: ".$v1_assignment_id.")\r\n");
                     }
@@ -1048,7 +1042,7 @@ switch ($action) {
 
         fclose($csvexport);
         if (!$trial) {
-            fputs($debug, "+".calcRunTime($startTime)." seconds - End Ajax call\r\n");
+            fputs($debug, "+".calcRunTime($startTime)." seconds - End Ajax call\r\n\r\n");
         }
         fclose($debug);
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -148,7 +148,8 @@
                 <FIELD NAME="submission_unanonreason" TYPE="text" LENGTH="medium" NOTNULL="false" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_unanon" NEXT="submission_transmatch"/>
                 <FIELD NAME="submission_transmatch" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_unanonreason" NEXT="submission_acceptnothing"/>
                 <FIELD NAME="submission_acceptnothing" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_transmatch" NEXT="submission_orcapable"/>
-                <FIELD NAME="submission_orcapable" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_acceptnothing"/>
+                <FIELD NAME="submission_orcapable" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_acceptnothing" NEXT="migration_gradebook"/>
+                <FIELD NAME="migration_gradebook" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_orcapable"/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="primary" TYPE="primary" FIELDS="id" />

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -147,13 +147,19 @@ function xmldb_turnitintooltwo_upgrade($oldversion) {
         }
     }
 
-    if ($oldversion < 2016011106) {
+    if ($oldversion < 2016011107) {
         $table = new xmldb_table('turnitintooltwo_courses');
         $field = new xmldb_field('migrated', XMLDB_TYPE_INTEGER, '1', false, true, false, '0', 'course_type');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
+        $table = new xmldb_table('turnitintooltwo_submissions');
+        $field = new xmldb_field('migration_gradebook', XMLDB_TYPE_INTEGER, '1', false, true, false, '0', 'submission_orcapable');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
     }
 
+    // Newer DB Man field ($name, $type=null, $precision=null, $unsigned=null, $notnull=null, $sequence=null, $default=null, $previous=null)
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@ if (empty($plugin)) {
 	$plugin = new StdClass();
 }
 
-$plugin->version   = 2016011106;
+$plugin->version   = 2016011107;
 $plugin->release   = "2.6+";
 $plugin->requires  = 2013111800;
 $plugin->component = 'mod_turnitintooltwo';


### PR DESCRIPTION
This changes the functionality of the migration tool to prevent the tool from exceeding the database transaction lock timeout limit when migrating a course. The scenario is caused by Moodle's gradebook updates being slow, which adds up quickly for thousands of submissions. 

The change moves this functionality from the migration tool to the background cron without affecting migrations. It updates the gradebook in order of latest modified submissions.

Also some slight modifications to the debug output layout.