### PR TITLE
Fix log directory permissions

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -142,7 +142,7 @@ function turnitintooltwo_activitylog($string, $activity) {
 
         $dirpath = $CFG->tempdir."/turnitintooltwo/logs";
         if (!file_exists($dirpath)) {
-            mkdir($dirpath, 0777, true);
+            mkdir($dirpath, $CFG->directorypermissions, true);
         }
         $dir = opendir($dirpath);
         $files = array();

--- a/turnitintooltwo_perflog.class.php
+++ b/turnitintooltwo_perflog.class.php
@@ -25,7 +25,7 @@ class turnitintooltwo_performancelog extends PerformanceLog {
 
             $dirpath = $CFG->tempdir."/turnitintooltwo/logs";
             if (!file_exists($dirpath)) {
-                mkdir($dirpath, 0777, true);
+                mkdir($dirpath, $CFG->directorypermissions, true);
             }
             $dir = opendir($dirpath);
             $files = array();


### PR DESCRIPTION
Use configured permissions instead of the hard-coded 0777 which is bad security-wise.
