### PR TITLE
CCLE notify nonsubmitter emailsentto inactive student

### DIFF
--- a/view.php
+++ b/view.php
@@ -396,8 +396,9 @@ if (!empty($action)) {
                 $params = array('turnitintooltwoid' => $turnitintooltwo->id, 'submission_part' => $part);
                 $submittedusers = $DB->get_records('turnitintooltwo_submissions', $params, '', 'userid');
 
-                // Send message to all non submitted users.
-                $nonsubmittedusers = array_diff_key((array)$allusers, (array)$submittedusers);
+                // Send message to all non submitted users excludes inactive students.
+                $susers = get_suspended_userids($context);
+                $nonsubmittedusers = array_diff_key((array)$allusers, (array)$susers, (array)$submittedusers);
                 foreach ($nonsubmittedusers as $nonsubmitteduser) {
                     //Send a message to the user's Moodle inbox with the digital receipt.
                     $nonsubmitters->send_message($nonsubmitteduser->id, $subject, $message);


### PR DESCRIPTION
Currently it sends non-submitter notification email to inactive students.  This commit will fix the issue.
