### PR TITLE
INT-7637 - Fix submission processing message in Moodle 3.1

### DIFF
--- a/jquery/turnitintooltwo.js
+++ b/jquery/turnitintooltwo.js
@@ -60,16 +60,7 @@ jQuery(document).ready(function($) {
 
     // Show loading if submission passes validation
     $(document).on('submit', '.submission_form_container form', function() {
-        try {
-            var myValidator = validate_turnitintooltwo_form;
-        } catch(e) {
-            return true;
-        }
-
-        var validated = myValidator(this);
-
-        if (validated) {
-
+        if ($("#id_submissiontitle").val().length > 0) {
             $("#general").slideUp('slow');
             $(".mod_turnitintooltwo .noticebox").slideUp('slow');
             $(".submission_form_container form").slideUp('slow');


### PR DESCRIPTION
In Moodle 3.1 the submission processing text and icon are not being displayed as the form validation stopped working in 3.1. this pull request fixes that.