### PR TITLE
INT-7659 Fix for deleted Turnitin student not allowing inbox to load

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1546,9 +1546,11 @@ class turnitintooltwo_assignment {
             $readsubmissions = $response->getSubmissions();
 
             foreach ($readsubmissions as $readsubmission) {
-                $turnitintooltwosubmission = new turnitintooltwo_submission($readsubmission->getSubmissionId(),
+                if ($readsubmission->getAuthorUserId() != "-1") {
+                    $turnitintooltwosubmission = new turnitintooltwo_submission($readsubmission->getSubmissionId(),
                                                                                 "turnitin", $this, $part->id);
-                $turnitintooltwosubmission->save_updated_submission_data($readsubmission, true);
+                    $turnitintooltwosubmission->save_updated_submission_data($readsubmission, true);
+                }
             }
 
         } catch (Exception $e) {


### PR DESCRIPTION
If a student has been deleted in Turnitin and has a submission in Moodle then the assignment inbox will fail to load. This fixes the issue by detecting the deleted user and not refreshing the submission.