### PR TITLE
Add support for two V2 courses

### DIFF
--- a/classes/helpdeskwizard/helpdeskwizard.php
+++ b/classes/helpdeskwizard/helpdeskwizard.php
@@ -79,7 +79,7 @@ class helpdeskwizard {
      * @param int - $id module id, 0 by default to indicate that it's not been accessed from a module.
      * @return mixed - html containing helpdesk solutions.
      */
-    public function output_wizard($id = 0) {
+    public function output_wizard($id = 0, $legacy = 0) {
         $xml = $this->read_xml_solutions_file();
         $categories = array();
         $output = "";
@@ -93,7 +93,6 @@ class helpdeskwizard {
             // Read all issues into the array by category.
             $i = 0;
             foreach ($solutions as $solution) {
-                $solution = array();
                 $i++;
                 foreach ($solution as $k => $v) {
                     $solution[$k] = (string)$v;
@@ -145,7 +144,7 @@ class helpdeskwizard {
 
         // Show link to support form.
         $formlink = html_writer::tag('h2', 'Did you find your answer?');
-        $formlink .= html_writer::tag('button', 'No, I Need More Help', array('id' => 'btn_supportform', 'class' => 'btn'));
+        $formlink .= html_writer::tag('button', 'No, I Need More Help', array('id' => 'btn_supportform', 'class' => 'btn', 'data-legacy' => $legacy));
         $formlink .= html_writer::tag('div', $id, array('id' => 'tii_helpdesk_mod_id'));
         $output .= html_writer::tag('div', $formlink, array('id' => 'btn_tiisupportform_link'));
 

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -70,36 +70,9 @@ class v1migration {
 		// Migrate Users.
 		$this->migrate_users();
 
-		/**
-         * Handle situation where a V2 course already exists.
-         * THIS WILL DIFFER IN THE ACTUAL MIGRATION TOOL.
-         * In the actual version we will insert a new course and handle the situation of two Turnitin class IDs in v2.
-         */
+        // Migrate course.
         $v1course = $DB->get_record('turnitintool_courses', array('courseid' => $this->courseid));
-        $v2course = $DB->get_record('turnitintooltwo_courses', array('courseid' => $v1course->courseid, 'course_type' => 'TT'));
-
-        if (!$v2course) {
-            // Insert the course to the Turnitintooltwo courses table.
-            $v2course = new stdClass();
-            $v2course->courseid = $v1course->courseid;
-            $v2course->ownerid = $v1course->ownerid;
-            $v2course->turnitin_ctl = $v1course->turnitin_ctl;
-            $v2course->turnitin_cid = $v1course->turnitin_cid;
-            $v2course->course_type = 'TT';
-            $v2course->migrated = 1;
-
-            $DB->insert_record('turnitintooltwo_courses', $v2course);
-        } else {
-            // This code is commented out and is buggy in this version of the migration tool. The code will be removed with the tickets for 2 class support.
-            
-            // $update = new stdClass();
-            // $update->id = $v1course->id;
-            // $update->turnitin_cid = $v2course->turnitin_cid;
-            // $DB->update_record('turnitintool_courses', $update);
-            // $update->id = $v2course->id;
-            // $update->migrated = 1;
-            // $DB->update_record('turnitintooltwo_courses', $update);
-        }
+        $this->migrate_course($v1course);
 
         // Initialise any null values that are now not allowed. 
         $this->set_default_values();
@@ -275,4 +248,47 @@ class v1migration {
             }
         }
 	}
+
+    /**
+     *  Migrate the users from v1 to v2 - only if the user does not already exist in turnitintooltwo_users.
+     */
+    function migrate_course() {
+        global $DB;
+
+        // We may have more than one course if the course contained V2 assignments prior to the first V1 migration.
+        $v2courses = $DB->get_records('turnitintool_courses', array('courseid' => $this->courseid));
+
+        // Check each course to see if we can use an existing course for this migration.
+        foreach ($v2courses as $v2course) {
+            $v1part->turnitintooltwoid = $turnitintooltwoid;
+
+            if ($v2course->turnitin_cid == $v1course->turnitin_cid) {
+                return;
+            } elseif ($v2course->course_type == "V1") {
+                return;
+            }
+        }
+
+        // If there are V2 courses and we did not return during the above checks, we are migrating the first assignment on a course with pre-existing V2 assignments.
+        if (count($v2courses) > 0) {
+            $coursetype = "V1";
+
+            // This flag is used to call the correct course from turnitintooltwo_courses table in cases where we have a second course.
+            $this->v1assignment->legacy = 1;
+        } else {
+            $coursetype = "TT";
+        }
+
+        // As we didn't return during the above checks, we need to insert a new course.
+        $turnitincourse = new stdClass();
+        $turnitincourse->courseid = $v1course->courseid;
+        $turnitincourse->ownerid = $v1course->ownerid;
+        $turnitincourse->turnitin_ctl = $v1course->turnitin_ctl;
+        $turnitincourse->turnitin_cid = $v1course->turnitin_cid;
+        $turnitincourse->course_type = $coursetype;
+        $turnitincourse->migrated = 1;
+
+        // Insert the course to the turnitintooltwo courses table.
+        $DB->insert_record('turnitintooltwo_courses', $turnitincourse);
+    }
 }

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -296,8 +296,8 @@ class v1migration {
         $v2course->migrated = 1;
 
         // Insert the course to the turnitintooltwo courses table.
-        $DB->insert_record('turnitintooltwo_courses', $v2course);
-        $v2course = $DB->get_record('turnitintooltwo_courses', array('courseid' => $v2course->courseid, 'course_type' => $coursetype));
+        $id = $DB->insert_record('turnitintooltwo_courses', $v2course);
+        $v2course->id = $id;
 
         return $v2course;
     }

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -266,8 +266,6 @@ class v1migration {
 
         // Check each course to see if we can use an existing course for this migration.
         foreach ($v2courses as $v2course) {
-            $v1part->turnitintooltwoid = $turnitintooltwoid;
-
             if (($v2course->course_type == "TT") && ($v2course->turnitin_cid == $v1course->turnitin_cid)) {
                 return;
             } elseif ($v2course->course_type == "V1") {
@@ -289,16 +287,16 @@ class v1migration {
         }
 
         // As we didn't return during the above checks, we need to insert a new course.
-        $turnitincourse = new stdClass();
-        $turnitincourse->courseid = $v1course->courseid;
-        $turnitincourse->ownerid = $v1course->ownerid;
-        $turnitincourse->turnitin_ctl = $v1course->turnitin_ctl;
-        $turnitincourse->turnitin_cid = $v1course->turnitin_cid;
-        $turnitincourse->course_type = $coursetype;
-        $turnitincourse->migrated = 1;
+        $v2course = new stdClass();
+        $v2course->courseid = $v1course->courseid;
+        $v2course->ownerid = $v1course->ownerid;
+        $v2course->turnitin_ctl = $v1course->turnitin_ctl;
+        $v2course->turnitin_cid = $v1course->turnitin_cid;
+        $v2course->course_type = $coursetype;
+        $v2course->migrated = 1;
 
         // Insert the course to the turnitintooltwo courses table.
-        $DB->insert_record('turnitintooltwo_courses', $turnitincourse);
+        $DB->insert_record('turnitintooltwo_courses', $v2course);
     }
 }
 

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -265,6 +265,9 @@ class v1migration {
             if ($v2course->turnitin_cid == $v1course->turnitin_cid) {
                 return;
             } elseif ($v2course->course_type == "V1") {
+                // This flag is used to call the correct course from turnitintooltwo_courses table in cases where we have a second course.
+                $this->v1assignment->legacy = 1;
+
                 return;
             }
         }

--- a/extras.php
+++ b/extras.php
@@ -83,7 +83,8 @@ switch ($cmd) {
 
         include("classes/helpdeskwizard/helpdeskwizard.php");
         $helpdeskwizard = new helpdeskwizard();
-        $output = $helpdeskwizard->output_wizard($id);
+        $legacy = required_param('legacy', PARAM_INT);
+        $output = $helpdeskwizard->output_wizard($id, $legacy);
         break;
 
     case "supportform":
@@ -94,7 +95,10 @@ switch ($cmd) {
         // Get the Turnitin class id if we are in a class context.
         $tiiclass = 0;
         if ($id != 0) {
-            $course = turnitintooltwo_assignment::get_course_data($course->id);
+            $legacy = required_param('legacy', PARAM_INT);
+            $coursetype = $legacy ? "V1" : "TT";
+
+            $course = turnitintooltwo_assignment::get_course_data($course->id, $coursetype);
             $tiiclass = (isset($course->turnitin_cid)) ? $course->turnitin_cid : 0;
         }
 

--- a/jquery/turnitin_helpdesk.js
+++ b/jquery/turnitin_helpdesk.js
@@ -39,10 +39,11 @@ jQuery(document).ready(function($) {
     // Pass categories and module id to support form.
     $(document).on('click', '#btn_supportform', function() {
         var id = $('#tii_helpdesk_mod_id').html();
+        var legacy = $(this).data("legacy");
         var category = $('.tii_helpdesk_category').val();
         var sub_category = $('.tii_helpdesk_sub_category').val();
 
-        var querystr = '&id=' + id + '&category=' + category + '&sub_category=' + sub_category;
+        var querystr = '&id=' + id + '&legacy=' + legacy + '&category=' + category + '&sub_category=' + sub_category;
 
         window.location.href = M.cfg.wwwroot + '/mod/turnitintooltwo/extras.php?cmd=supportform' + querystr;
     });

--- a/lang/en/turnitintooltwo.php
+++ b/lang/en/turnitintooltwo.php
@@ -572,3 +572,4 @@ $string['migrationtooltitle'] = 'Would you like to migrate this assignment to Mo
 $string['migrationtoolinfo'] = 'Blurb here about the migration tool etc. This needs to be written by the technical author team';
 $string['migrateassignment'] = 'Migrate Assignment';
 $string['dontmigrateassignment'] = 'Continue Without Migrating';
+$string['tii2updateerror'] = 'There was a problem updating the Turnitin Assignment 2 in the database.<br />';

--- a/lib.php
+++ b/lib.php
@@ -347,6 +347,19 @@ function turnitintooltwo_duplicate_recycle($courseid, $action) {
         foreach ($parts as $part) {
             $partsarray[$courseid][$turnitintooltwo->id][$part->id]['tiiassignid'] = $part->tiiassignid;
         }
+
+        /* Set legacy to 0 for all TII2s so that we can have all recreated assignments on the same TII class.
+           Legacy is set to 1 only for migrated assignments that were migrated on a course where there were pre-existing V2 assignments.*/
+        if ($action == "NEWCLASS") {
+            $update->id = $turnitintooltwo->id;
+            $update->legacy = 0;
+            if (!$DB->update_record('turnitintooltwo', $update)) {
+                turnitintooltwo_print_error('tii2updateerror', 'turnitintooltwo', null, null, __FILE__, __LINE__);
+                exit();
+            } else {
+                turnitintooltwo_activitylog("Assignment updated (".$turnitintooltwo->id.")", "REQUEST");
+            }
+        }
     }
 
     $currentcourse = turnitintooltwo_assignment::get_course_data($courseid);
@@ -1647,4 +1660,16 @@ function turnitintooltwo_genUuid() {
         mt_rand( 0, 0xffff ),
         mt_rand( 0, 0xffff )
     );
+}
+
+/**
+ * @param  $legacy The flag for whether we are using a legacy assignment or not.
+ * @return string The course type for this assignment.
+ */
+function turnitintooltwo_get_course_type($legacy) {
+    if ($legacy) {
+        return "V1";
+    } else {
+        return "TT";
+    }
 }

--- a/lib.php
+++ b/lib.php
@@ -1667,7 +1667,7 @@ function turnitintooltwo_genUuid() {
  * @return string The course type for this assignment.
  */
 function turnitintooltwo_get_course_type($legacy) {
-    if ($legacy) {
+    if ($legacy == 1) {
         return "V1";
     } else {
         return "TT";

--- a/tests/unit/classes/v1migration/v1migration_test.php
+++ b/tests/unit/classes/v1migration/v1migration_test.php
@@ -328,4 +328,88 @@ class mod_turnitintooltwo_v1migration_testcase extends advanced_testcase {
         $v2parts = $DB->get_records('turnitintooltwo_submissions', array('turnitintooltwoid' => $v2assignmentid));
         $this->assertEquals(1, count($v2parts));
     }
+
+    /**
+     * Test the modal that appears when asked to migrate.
+     */
+    public function test_migrate_course() {
+        global $DB;
+
+        if (!$this->v1installed()) {
+            return false;
+        }
+
+        $assignment = new stdClass();
+        $v1migration = new v1migration(1, $assignment);
+
+        $this->resetAfterTest();
+
+        // Values for our TII course.
+        $v1tiicourse = 9;
+        $v2tiicourse = 12;
+
+        // Create a V1 course and get it.
+        $course = new stdClass();
+        $course->courseid = 1;
+        $course->ownerid = 1;
+        $course->turnitin_ctl = "Test Course";
+        $course->turnitin_cid = $v1tiicourse;
+        $course->course_type = "TT";
+
+        // Insert the course to the turnitintooltwo courses table.
+        $DB->insert_record('turnitintool_courses', $course);
+        $v1course = $DB->get_record('turnitintool_courses', array('courseid' => 1));
+
+        /* Test 1. V1 migration with no existing V2 courses.
+           Should create a new course entry in turnitintooltwo_courses table with the same turnitin_cid as above, course type TT.*/
+        $test = $v1migration->migrate_course($v1course);
+        $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
+        $this->assertEquals(1, count($v2courses));
+
+        // If we attempt to migrate this course again (IE migrating a second assignment on this course), there should still only be one entry.
+        $test = $v1migration->migrate_course($v1course);
+        $v2course = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
+        $this->assertEquals(1, count($v2course));
+
+        // Clear our table.
+        $DB->delete_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse));
+
+        /* Test 2. V1 migration with an existing V2 course.
+           Should create a new course entry in turnitintooltwo_courses table with the same turnitin_cid as above, course type V1. 
+           Legacy field should be set to 1 on these tests. */
+
+        // Create our initial V2 course.
+        $v1iicourse = 9;
+
+        $course = new stdClass();
+        $course->courseid = 1;
+        $course->ownerid = 1;
+        $course->turnitin_ctl = "Test Course";
+        $course->turnitin_cid = $v2tiicourse;
+        $course->course_type = "TT";
+
+        // Insert the course to the turnitintooltwo courses table.
+        $DB->insert_record('turnitintooltwo_courses', $course);
+
+        $test = $v1migration->migrate_course($v1course);
+        $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "V1"));
+        $this->assertEquals(1, count($v2courses));
+        $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+
+        // We expect 0 results here since we inserted a course type of TT.
+        $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
+        $this->assertEquals(0, count($v2courses));
+        $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+
+        // If we attempt to migrate this course again (IE migrating a second assignment on this course), there should still only be one entry.
+        $test = $v1migration->migrate_course($v1course);
+        $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "V1"));
+        $this->assertEquals(1, count($v2courses));
+        $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+
+        // And still 0 results for this one.
+        $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
+        $this->assertEquals(0, count($v2courses));
+        $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+    }
 }

--- a/tests/unit/classes/v1migration/v1migration_test.php
+++ b/tests/unit/classes/v1migration/v1migration_test.php
@@ -362,14 +362,18 @@ class mod_turnitintooltwo_v1migration_testcase extends advanced_testcase {
 
         /* Test 1. V1 migration with no existing V2 courses.
            Should create a new course entry in turnitintooltwo_courses table with the same turnitin_cid as above, course type TT.*/
-        $test = $v1migration->migrate_course($v1course);
+        $response = $v1migration->migrate_course($v1course);
         $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
         $this->assertEquals(1, count($v2courses));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals($course->course_type, $response->course_type);
 
         // If we attempt to migrate this course again (IE migrating a second assignment on this course), there should still only be one entry.
-        $test = $v1migration->migrate_course($v1course);
+        $response = $v1migration->migrate_course($v1course);
         $v2course = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
         $this->assertEquals(1, count($v2course));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals($course->course_type, $response->course_type);
 
         // Clear our table.
         $DB->delete_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse));
@@ -391,25 +395,33 @@ class mod_turnitintooltwo_v1migration_testcase extends advanced_testcase {
         // Insert the course to the turnitintooltwo courses table.
         $DB->insert_record('turnitintooltwo_courses', $course);
 
-        $test = $v1migration->migrate_course($v1course);
+        $response = $v1migration->migrate_course($v1course);
         $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "V1"));
         $this->assertEquals(1, count($v2courses));
         $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals("V1", $response->course_type);
 
         // We expect 0 results here since we inserted a course type of TT.
         $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
         $this->assertEquals(0, count($v2courses));
         $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals("V1", $response->course_type);
 
         // If we attempt to migrate this course again (IE migrating a second assignment on this course), there should still only be one entry.
-        $test = $v1migration->migrate_course($v1course);
+        $response = $v1migration->migrate_course($v1course);
         $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "V1"));
         $this->assertEquals(1, count($v2courses));
         $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals("V1", $response->course_type);
 
         // And still 0 results for this one.
         $v2courses = $DB->get_records('turnitintooltwo_courses', array('turnitin_cid' => $v1tiicourse, 'course_type' => "TT"));
         $this->assertEquals(0, count($v2courses));
         $this->assertEquals(1, count($v1migration->v1assignment->legacy));
+        $this->assertEquals($course->courseid, $response->courseid);
+        $this->assertEquals("V1", $response->course_type);
     }
 }

--- a/tests/unit/lib.php
+++ b/tests/unit/lib.php
@@ -1,0 +1,30 @@
+<?php
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/mod/turnitintooltwo/lib.php');
+
+/**
+ * Tests for lib file.
+ *
+ * @package turnitintooltwo
+ */
+class mod_lib_testcase extends advanced_testcase {
+    /**
+     * Test create submission function returns the expected bollean given a data array.
+     */
+    public function test_turnitintooltwo_get_course_type() {
+        $this->resetAfterTest();
+
+        $response = turnitintooltwo_get_course_type(1);
+        $this->assertEquals($response, "V1");
+
+        $response = turnitintooltwo_get_course_type(0);
+        $this->assertEquals($response, "TT");
+
+        $response = turnitintooltwo_get_course_type("foo");
+        $this->assertEquals($response, "TT");
+    }
+}

--- a/tests/unit/turnitintooltwo_assignment_test.php
+++ b/tests/unit/turnitintooltwo_assignment_test.php
@@ -34,45 +34,45 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/turnitintooltwo_assignment.cl
  */
 class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 
-	/**
-	 * Test that the title is truncated to the passed in limit.
-	 */
-	public function test_truncate_title() {
-		$turnitintooltwo = new stdClass();
-		$turnitintooltwo->id = 1;
+    /**
+     * Test that the title is truncated to the passed in limit.
+     */
+    public function test_truncate_title() {
+        $turnitintooltwo = new stdClass();
+        $turnitintooltwo->id = 1;
 
-		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
+        $turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
 
-		// Test that a string under the limit is returned with a suffix added.
-		$originaltitle = 'Test String';
-		$expectedtitle = 'Test String (Moodle TT)';
-		$limit = 100;
-		$title = $turnitintooltwoassignment->truncate_title($originaltitle, $limit, 'TT');
-		$this->assertEquals($expectedtitle, $title);
-		$this->assertLessThan($limit, strlen($title));
+        // Test that a string under the limit is returned with a suffix added.
+        $originaltitle = 'Test String';
+        $expectedtitle = 'Test String (Moodle TT)';
+        $limit = 100;
+        $title = $turnitintooltwoassignment->truncate_title($originaltitle, $limit, 'TT');
+        $this->assertEquals($expectedtitle, $title);
+        $this->assertLessThan($limit, strlen($title));
 
-		// Test that a string over the limit is returned truncated with a suffix added and is equal to the limit in length.
-		$originaltitle = 'Test String is truncated and has a suffix added on the end with brackets showing the moodle coursetype';
-		$limit = 30;
-		$title = $turnitintooltwoassignment->truncate_title($originaltitle, $limit, 'TT');
-		$this->assertContains('Test String', $title);
-		$this->assertNotContains('added on the end', $title);
-		$this->assertContains('... (Moodle TT)', $title);
-		$this->assertEquals($limit, strlen($title));
-	}
+        // Test that a string over the limit is returned truncated with a suffix added and is equal to the limit in length.
+        $originaltitle = 'Test String is truncated and has a suffix added on the end with brackets showing the moodle coursetype';
+        $limit = 30;
+        $title = $turnitintooltwoassignment->truncate_title($originaltitle, $limit, 'TT');
+        $this->assertContains('Test String', $title);
+        $this->assertNotContains('added on the end', $title);
+        $this->assertContains('... (Moodle TT)', $title);
+        $this->assertEquals($limit, strlen($title));
+    }
 
-	/**
-	 * Test that the course returned is the one we expect.
-	 */
-	public function test_course_data() {
+    /**
+     * Test that the course returned is the one we expect.
+     */
+    public function test_course_data() {
         global $DB;
 
         $this->resetAfterTest();
 
-		$turnitintooltwo = new stdClass();
-		$turnitintooltwo->id = 1;
+        $turnitintooltwo = new stdClass();
+        $turnitintooltwo->id = 1;
 
-		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
+        $turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
 
         // Create a V2 course.
         $course = new stdClass();
@@ -87,17 +87,17 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 
         // Test that we return the correct course when calling get_course_data with course type TT.
         $response = $turnitintooltwoassignment->get_course_data(1, "TT");
-		$this->assertEquals(10, $response->turnitin_cid);
-		$this->assertEquals("TT", $response->course_type);
+        $this->assertEquals(10, $response->turnitin_cid);
+        $this->assertEquals("TT", $response->course_type);
 
-		// Insert a new V2 course.
+        // Insert a new V2 course.
         $course->turnitin_cid = 20;
         $course->course_type = "V1";
         $DB->insert_record('turnitintooltwo_courses', $course);
 
         // Test course type V1
         $response = $turnitintooltwoassignment->get_course_data(1, "V1");
-		$this->assertEquals(20, $response->turnitin_cid);
-		$this->assertEquals("V1", $response->course_type);
+        $this->assertEquals(20, $response->turnitin_cid);
+        $this->assertEquals("V1", $response->course_type);
     }
 }

--- a/tests/unit/turnitintooltwo_assignment_test.php
+++ b/tests/unit/turnitintooltwo_assignment_test.php
@@ -61,4 +61,43 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 		$this->assertEquals($limit, strlen($title));
 	}
 
+	/**
+	 * Test that the course returned is the one we expect.
+	 */
+	public function test_course_data() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+		$turnitintooltwo = new stdClass();
+		$turnitintooltwo->id = 1;
+
+		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
+
+        // Create a V2 course.
+        $course = new stdClass();
+        $course->courseid = 1;
+        $course->ownerid = 1;
+        $course->turnitin_ctl = "Test Course";
+        $course->turnitin_cid = 10;
+        $course->course_type = "TT";
+
+        // Insert the course to the turnitintooltwo courses table.
+        $DB->insert_record('turnitintooltwo_courses', $course);
+
+        // Test that we return the correct course when calling get_course_data with course type TT.
+        $response = $turnitintooltwoassignment->get_course_data(1, "TT");
+		$this->assertEquals(10, $response->turnitin_cid);
+		$this->assertEquals("TT", $response->course_type);
+
+		// Insert a new V2 course.
+        $course->turnitin_cid = 20;
+        $course->course_type = "V1";
+        $DB->insert_record('turnitintooltwo_courses', $course);
+
+        // Test course type V1
+        $response = $turnitintooltwoassignment->get_course_data(1, "V1");
+		$this->assertEquals(20, $response->turnitin_cid);
+		$this->assertEquals("V1", $response->course_type);
+    }
 }

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -21,6 +21,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__."/lib.php");
 require_once(__DIR__.'/turnitintooltwo_comms.class.php');
 require_once(__DIR__.'/turnitintooltwo_user.class.php');
 require_once(__DIR__.'/turnitintooltwo_submission.class.php');
@@ -90,7 +91,8 @@ class turnitintooltwo_assignment {
      */
     public function add_tii_tutor($tutorid) {
         // Get Course data.
-        $course = $this->get_course_data($this->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($this->turnitintooltwo->legacy);
+        $course = $this->get_course_data($this->turnitintooltwo->course, $coursetype);
         $user = new turnitintooltwo_user($tutorid, 'Instructor');
         $notice = array();
 
@@ -497,7 +499,8 @@ class turnitintooltwo_assignment {
 
         $users = array();
         // Get Moodle Course Object.
-        $course = $this->get_course_data($this->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($this->turnitintooltwo->legacy);
+        $course = $this->get_course_data($this->turnitintooltwo->course, $coursetype);
         $classmembers = $this->get_class_memberships($course->turnitin_cid);
 
         $turnitincomms = new turnitintooltwo_comms();
@@ -581,7 +584,8 @@ class turnitintooltwo_assignment {
      */
     public function enrol_all_students($cm) {
         // Get Moodle Course Object.
-        $course = $this->get_course_data($this->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($this->turnitintooltwo->legacy);
+        $course = $this->get_course_data($this->turnitintooltwo->course, $coursetype);
 
         // Get local course members.
         $students = get_enrolled_users(context_module::instance($cm->id),
@@ -663,7 +667,8 @@ class turnitintooltwo_assignment {
         $config = turnitintooltwo_admin_config();
 
         // Get Moodle Course Object.
-        $course = $this->get_course_data($this->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($this->turnitintooltwo->legacy);
+        $course = $this->get_course_data($this->turnitintooltwo->course, $coursetype);
 
         // Get the Turnitin owner of this this Course or make user the owner if none.
         $ownerid = $this->get_tii_owner($course->id);
@@ -1289,7 +1294,8 @@ class turnitintooltwo_assignment {
         $this->turnitintooltwo->timemodified = time();
 
         // Get Moodle Course Object.
-        $course = $this->get_course_data($this->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($this->turnitintooltwo->legacy);
+        $course = $this->get_course_data($this->turnitintooltwo->course, $coursetype);
 
         // Get the Turnitin owner of this this Course or make user the owner if none.
         $ownerid = $this->get_tii_owner($course->id);

--- a/turnitintooltwo_submission.class.php
+++ b/turnitintooltwo_submission.class.php
@@ -16,6 +16,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__."/lib.php");
 require_once(__DIR__.'/classes/digitalreceipt/receipt_message.php');
 require_once(__DIR__.'/classes/digitalreceipt/instructor_message.php');
 
@@ -419,7 +420,8 @@ class turnitintooltwo_submission {
         $context = context_module::instance($cm->id);
 
         // Check if user is a member of class, if not then join them to it.
-        $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
+        $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
         $user = new turnitintooltwo_user($userid, 'Learner');
         $user->join_user_to_class($course->turnitin_cid);
         $user->edit_tii_user();
@@ -522,7 +524,8 @@ class turnitintooltwo_submission {
         $context = context_module::instance($cm->id);
 
         // Check if user is a member of class, if not then join them to it.
-        $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+        $coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
+        $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
         $user = new turnitintooltwo_user($this->userid, 'Learner');
         $user->join_user_to_class($course->turnitin_cid);
         $user->edit_tii_user();

--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -21,6 +21,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__."/lib.php");
 require_once(__DIR__.'/turnitintooltwo_form.class.php');
 
 class turnitintooltwo_view {
@@ -273,7 +274,8 @@ class turnitintooltwo_view {
         $eulaaccepted = false;
         if ($userid == $USER->id) {
             $user = new turnitintooltwo_user($userid, "Learner");
-            $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+            $coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
+            $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
             $user->join_user_to_class($coursedata->turnitin_cid);
             $eulaaccepted = ($user->useragreementaccepted != 1) ? $user->get_accepted_user_agreement() : $user->useragreementaccepted;
         }
@@ -841,7 +843,8 @@ class turnitintooltwo_view {
             // Show feature links (rubric and quickmark).
             if ($config->usegrademark) {
                 // Rubric Manager.
-                $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+                $coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
+                $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
                 $rubricmanagerlink = $OUTPUT->box_start('row_rubric_manager', '');
                 $rubricmanagerlink .= html_writer::link($CFG->wwwroot.
                                         '/mod/turnitintooltwo/extras.php?cmd=rubricmanager&tiicourseid='.
@@ -1330,7 +1333,8 @@ class turnitintooltwo_view {
             $eulaaccepted = 0;
             if ($submission->userid == $USER->id) {
                 $submissionuser = new turnitintooltwo_user($submission->userid, "Learner");
-                $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+                $coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
+                $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
                 $submissionuser->join_user_to_class($coursedata->turnitin_cid);
                 // Has the student accepted the EULA?
                 $eulaaccepted = $submissionuser->useragreementaccepted;

--- a/view.php
+++ b/view.php
@@ -468,7 +468,12 @@ $class = ($istutor) ? "js_required" : "";
 echo html_writer::start_tag("div", array("class" => $class));
 echo html_writer::tag("div", $viewcontext, array("id" => "view_context"));
 
-$course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+$coursetype = "TT";
+if ($turnitintooltwoassignment->turnitintooltwo->legacy) {
+    $coursetype = "V1";
+}
+
+$course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
 
 switch ($do) {
     case "submission_success":

--- a/view.php
+++ b/view.php
@@ -438,7 +438,8 @@ if ($viewcontext == "box" || $viewcontext == "box_solid") {
 
     // Show Helpdesk link for tutors if enabled.
     if ($istutor && $config->helpdeskwizard) {
-        $helpdesklink = html_writer::link($CFG->wwwroot.'/mod/turnitintooltwo/extras.php?id='.$id.'&cmd=supportwizard',
+        $helpdesklink = html_writer::link($CFG->wwwroot.'/mod/turnitintooltwo/extras.php?id='.$id.'&legacy='
+                                            .$turnitintooltwoassignment->turnitintooltwo->legacy.'&cmd=supportwizard',
                                             get_string('helpdesklink', 'turnitintooltwo'));
 
         echo html_writer::tag('p', $helpdesklink);
@@ -468,10 +469,8 @@ $class = ($istutor) ? "js_required" : "";
 echo html_writer::start_tag("div", array("class" => $class));
 echo html_writer::tag("div", $viewcontext, array("id" => "view_context"));
 
-$coursetype = "TT";
-if ($turnitintooltwoassignment->turnitintooltwo->legacy) {
-    $coursetype = "V1";
-}
+// Get the course type for this assignment.
+$coursetype = turnitintooltwo_get_course_type($turnitintooltwoassignment->turnitintooltwo->legacy);
 
 $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
 
@@ -574,7 +573,7 @@ switch ($do) {
     case "rubricview":
         if (has_capability('mod/turnitintooltwo:submit', context_module::instance($cm->id))) {
             $user = new turnitintooltwo_user($USER->id, "Learner");
-            $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+            $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
             $user->join_user_to_class($course->turnitin_cid);
 
             echo html_writer::tag("div", $turnitintooltwoview->output_lti_form_launch('rubric_view', 'Learner',
@@ -630,7 +629,7 @@ switch ($do) {
 
             $eulaaccepted = false;
             $user = new turnitintooltwo_user($USER->id, $userrole);
-            $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+            $coursedata = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
             $user->join_user_to_class($coursedata->turnitin_cid);
             // Has the student accepted the EULA?
             $eulaaccepted = $user->useragreementaccepted;
@@ -676,7 +675,7 @@ switch ($do) {
 
         // Get course data.
         if ($istutor) {
-            $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course);
+            $course = $turnitintooltwoassignment->get_course_data($turnitintooltwoassignment->turnitintooltwo->course, $coursetype);
         }
 
         // Update Assignment from Turnitin on first visit.
@@ -791,4 +790,5 @@ foreach ($parts as $part) {
 }
 $partsstring .= ")";
 $courseid = $course->turnitin_cid;
+
 echo '<!-- Turnitin Moodle Direct Version: '.turnitintooltwo_get_version().' - course ID: '.$courseid.' - '.$partsstring.' -->';


### PR DESCRIPTION
Add support for two V2 courses.

This solves the issue where we have pre-existing V2 assignments on a course with a different Turnitin class to the V1 assignment.

Also passed in a course type parameter to help differentiate between the two courses, and a legacy field to indicate which course should be looked up post-migration.