### PR TITLE
Fix checkbox settings that were always being set to 0

### DIFF
--- a/tests/unit/turnitintooltwo_assignment_test.php
+++ b/tests/unit/turnitintooltwo_assignment_test.php
@@ -62,42 +62,29 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 	}
 
 	/**
-	 * Test that the checkbox fields are set to the correct values.
+	 * Test that a checkbox field is initialised and not overwritten if already set.
 	 */
-	public function test_set_checkbox_fields() {
+	public function test_set_checkbox_field() {
 		$turnitintooltwo = new stdClass();
 		$turnitintooltwo->id = 1;
 
 		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);		
-		$turnitintooltwoassignment->set_checkbox_fields();
+		$turnitintooltwoassignment->set_checkbox_field('testvar1');
 
-		// Verify that checkbox fields are set.
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_spelling);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_grammar);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_usage);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_mechanics);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_style);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->transmatch);
-		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->institution_check);
+		// Verify that checkbox fields are set to 0 by default.
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->testvar1);
+
+		// Verify that checkbox fields are set to passed in value.
+		$value = 20;
+		$turnitintooltwoassignment->set_checkbox_field('testvar2', $value);
+		$this->assertEquals($value, $turnitintooltwoassignment->turnitintooltwo->testvar2);
 
 		// Set checkbox fields.
-		$turnitintooltwoassignment->turnitintooltwo->erater_spelling = 1;
-		$turnitintooltwoassignment->turnitintooltwo->erater_grammar = 1;
-		$turnitintooltwoassignment->turnitintooltwo->erater_usage = 1;
-		$turnitintooltwoassignment->turnitintooltwo->erater_mechanics = 1;
-		$turnitintooltwoassignment->turnitintooltwo->erater_style = 1;
-		$turnitintooltwoassignment->turnitintooltwo->transmatch = 1;
-		$turnitintooltwoassignment->turnitintooltwo->institution_check = 1;
+		$turnitintooltwoassignment->turnitintooltwo->testvar1 = 1;
 
 		// Verify that checkbox fields aren't changed as they are already set.
-		$turnitintooltwoassignment->set_checkbox_fields();
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_spelling);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_grammar);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_usage);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_mechanics);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_style);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->transmatch);
-		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->institution_check);
+		$turnitintooltwoassignment->set_checkbox_field('testvar1');
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->testvar1);
 	}
 
 }

--- a/tests/unit/turnitintooltwo_assignment_test.php
+++ b/tests/unit/turnitintooltwo_assignment_test.php
@@ -61,4 +61,43 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 		$this->assertEquals($limit, strlen($title));
 	}
 
+	/**
+	 * Test that the checkbox fields are set to the correct values.
+	 */
+	public function test_set_checkbox_fields() {
+		$turnitintooltwo = new stdClass();
+		$turnitintooltwo->id = 1;
+
+		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);		
+		$turnitintooltwoassignment->set_checkbox_fields();
+
+		// Verify that checkbox fields are set.
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_spelling);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_grammar);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_usage);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_mechanics);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->erater_style);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->transmatch);
+		$this->assertEquals(0, $turnitintooltwoassignment->turnitintooltwo->institution_check);
+
+		// Set checkbox fields.
+		$turnitintooltwoassignment->turnitintooltwo->erater_spelling = 1;
+		$turnitintooltwoassignment->turnitintooltwo->erater_grammar = 1;
+		$turnitintooltwoassignment->turnitintooltwo->erater_usage = 1;
+		$turnitintooltwoassignment->turnitintooltwo->erater_mechanics = 1;
+		$turnitintooltwoassignment->turnitintooltwo->erater_style = 1;
+		$turnitintooltwoassignment->turnitintooltwo->transmatch = 1;
+		$turnitintooltwoassignment->turnitintooltwo->institution_check = 1;
+
+		// Verify that checkbox fields aren't changed as they are already set.
+		$turnitintooltwoassignment->set_checkbox_fields();
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_spelling);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_grammar);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_usage);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_mechanics);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->erater_style);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->transmatch);
+		$this->assertEquals(1, $turnitintooltwoassignment->turnitintooltwo->institution_check);
+	}
+
 }

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1330,40 +1330,7 @@ class turnitintooltwo_assignment {
         $this->turnitintooltwo->usegrademark = $config->usegrademark;
 
         // Set the checkbox settings for updates.
-        $this->turnitintooltwo->erater_spelling = 0;
-        if (isset($this->turnitintooltwo->erater_spelling)) {
-            $this->turnitintooltwo->erater_spelling = $this->turnitintooltwo->erater_spelling;
-        }
-
-        $this->turnitintooltwo->erater_grammar = 0;
-        if (isset($this->turnitintooltwo->erater_grammar)) {
-            $this->turnitintooltwo->erater_grammar = $this->turnitintooltwo->erater_grammar;
-        }
-
-        $this->turnitintooltwo->erater_usage = 0;
-        if (isset($this->turnitintooltwo->erater_usage)) {
-            $this->turnitintooltwo->erater_usage = $this->turnitintooltwo->erater_usage;
-        }
-
-        $this->turnitintooltwo->erater_mechanics = 0;
-        if (isset($this->turnitintooltwo->erater_mechanics)) {
-            $this->turnitintooltwo->erater_mechanics = $this->turnitintooltwo->erater_mechanics;
-        }
-
-        $this->turnitintooltwo->erater_style = 0;
-        if (isset($this->turnitintooltwo->erater_style)) {
-            $this->turnitintooltwo->erater_style = $this->turnitintooltwo->erater_style;
-        }
-
-        $this->turnitintooltwo->transmatch = 0;
-        if (isset($this->turnitintooltwo->transmatch)) {
-            $this->turnitintooltwo->transmatch = $this->turnitintooltwo->transmatch;
-        }
-
-        $this->turnitintooltwo->institution_check = 0;
-        if (isset($this->turnitintooltwo->institution_check)) {
-            $this->turnitintooltwo->institution_check = $this->turnitintooltwo->institution_check;
-        }
+        $this->set_checkbox_fields();
 
         // Update each individual part.
         for ($i = 1; $i <= $this->turnitintooltwo->numparts; $i++) {
@@ -1534,6 +1501,47 @@ class turnitintooltwo_assignment {
             turnitintooltwo_grade_item_update($this->turnitintooltwo);
         }
         return $update;
+    }
+
+    /**
+     * Set checkbox fields (erater, transmatch and institution_check) when editing an assignment.
+     */
+    public function set_checkbox_fields() {
+
+        $eraterspelling = 0;
+        if (!isset($this->turnitintooltwo->erater_spelling)) {
+            $this->turnitintooltwo->erater_spelling = $eraterspelling;
+        }
+
+        $eratergrammar = 0;
+        if (!isset($this->turnitintooltwo->erater_grammar)) {
+            $this->turnitintooltwo->erater_grammar = $eratergrammar;
+        }
+
+        $eraterusage = 0;
+        if (!isset($this->turnitintooltwo->erater_usage)) {
+            $this->turnitintooltwo->erater_usage = $eraterusage;
+        }
+
+        $eratermechanics = 0;
+        if (!isset($this->turnitintooltwo->erater_mechanics)) {
+            $this->turnitintooltwo->erater_mechanics = $eratermechanics;
+        }
+
+        $eraterstyle = 0;
+        if (!isset($this->turnitintooltwo->erater_style)) {
+            $this->turnitintooltwo->erater_style = $eraterstyle;
+        }
+
+        $transmatch = 0;
+        if (!isset($this->turnitintooltwo->transmatch)) {
+            $this->turnitintooltwo->transmatch = $transmatch;
+        }
+
+        $institutioncheck = 0;
+        if (!isset($this->turnitintooltwo->institution_check)) {
+            $this->turnitintooltwo->institution_check = $institutioncheck;
+        }
     }
 
     /**

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1329,8 +1329,11 @@ class turnitintooltwo_assignment {
         // Update GradeMark setting depending on config setting.
         $this->turnitintooltwo->usegrademark = $config->usegrademark;
 
-        // Set the checkbox settings for updates.
-        $this->set_checkbox_fields();
+        // Set the checkbox fields.
+        $chkboxfields = array('erater_spelling', 'erater_grammar', 'erater_usage', 'erater_mechanics', 'erater_style', 'transmatch', 'institution_check');
+        foreach ($chkboxfields as $field) {
+            $this->set_checkbox_field($field, 0);
+        }
 
         // Update each individual part.
         for ($i = 1; $i <= $this->turnitintooltwo->numparts; $i++) {
@@ -1504,43 +1507,11 @@ class turnitintooltwo_assignment {
     }
 
     /**
-     * Set checkbox fields (erater, transmatch and institution_check) when editing an assignment.
+     * Initialise a checkbox value that may not have been set in the edit module form.
      */
-    public function set_checkbox_fields() {
-
-        $eraterspelling = 0;
-        if (!isset($this->turnitintooltwo->erater_spelling)) {
-            $this->turnitintooltwo->erater_spelling = $eraterspelling;
-        }
-
-        $eratergrammar = 0;
-        if (!isset($this->turnitintooltwo->erater_grammar)) {
-            $this->turnitintooltwo->erater_grammar = $eratergrammar;
-        }
-
-        $eraterusage = 0;
-        if (!isset($this->turnitintooltwo->erater_usage)) {
-            $this->turnitintooltwo->erater_usage = $eraterusage;
-        }
-
-        $eratermechanics = 0;
-        if (!isset($this->turnitintooltwo->erater_mechanics)) {
-            $this->turnitintooltwo->erater_mechanics = $eratermechanics;
-        }
-
-        $eraterstyle = 0;
-        if (!isset($this->turnitintooltwo->erater_style)) {
-            $this->turnitintooltwo->erater_style = $eraterstyle;
-        }
-
-        $transmatch = 0;
-        if (!isset($this->turnitintooltwo->transmatch)) {
-            $this->turnitintooltwo->transmatch = $transmatch;
-        }
-
-        $institutioncheck = 0;
-        if (!isset($this->turnitintooltwo->institution_check)) {
-            $this->turnitintooltwo->institution_check = $institutioncheck;
+    public function set_checkbox_field($field, $value = 0) {
+        if (!isset($this->turnitintooltwo->$field)) {
+            $this->turnitintooltwo->$field = $value;
         }
     }
 


### PR DESCRIPTION
This fixes checkbox settings when editing an assignment that were always being set to 0, irrespective of what they were set to.