### PR TITLE
modify hash generation to use uniqid with extra unique-ness

### DIFF
--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -176,7 +176,7 @@ class v1migration {
 
                 // WILL NEED TO REJIG THIS IN FINAL VERSION.
                 // We can't leave as is, otherwise we could have a clash with existing V2 assignment hashes.
-                $v1partsubmission->submission_hash = rand(1000, 100000000);;
+                $v1partsubmission->submission_hash = uniqid("v1v2migration", true);
 
                 unset($v1partsubmission->turnitintoolid);
                 unset($v1partsubmission->id);

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -174,7 +174,7 @@ class v1migration {
                 $v1partsubmission->submission_part = $v2partid;
                 $v1partsubmission->migrate_gradebook = 1;
 
-                $v1partsubmission->submission_hash = $v1partsubmission->userid.‘_’.$turnitintooltwoid.‘_’.$v2partid;
+                $v1partsubmission->submission_hash = $v1partsubmission->userid.'_'.$turnitintooltwoid.'_'.$v2partid;
 
                 unset($v1partsubmission->turnitintoolid);
                 unset($v1partsubmission->id);

--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -174,9 +174,7 @@ class v1migration {
                 $v1partsubmission->submission_part = $v2partid;
                 $v1partsubmission->migrate_gradebook = 1;
 
-                // WILL NEED TO REJIG THIS IN FINAL VERSION.
-                // We can't leave as is, otherwise we could have a clash with existing V2 assignment hashes.
-                $v1partsubmission->submission_hash = uniqid("v1v2migration", true);
+                $v1partsubmission->submission_hash = $v1partsubmission->userid.‘_’.$turnitintooltwoid.‘_’.$v2partid;
 
                 unset($v1partsubmission->turnitintoolid);
                 unset($v1partsubmission->id);


### PR DESCRIPTION
Added extra uniqueness to the hashing.
Unit test failures detected, but are unrelated to this change:
```
1) mod_lib_testcase::test_turnitintooltwo_cron_migrate_gradebook_1000
Failed asserting that 400 matches expected 0.
```