### PR TITLE
INT-9107: Fix debug length check

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -916,6 +916,7 @@ switch ($action) {
             }
 
             echo json_encode($errorresponse);
+            exit();
         }
 
     case "check_migrated":

--- a/jquery/turnitintooltwo_migration_tool.js
+++ b/jquery/turnitintooltwo_migration_tool.js
@@ -77,7 +77,7 @@ function migrate(courseid, turnitintoolid) {
                 .prepend('<div id="full-error" class="box generalbox noticebox">' + data.error + ' ' + data.message + '</div>');
 
             // Check if we have a stack trace included.
-            if (data.trace.length > 0) {
+            if (data.hasOwnProperty('trace')) {
                 console.error(data.message);
                 console.error(JSON.stringify(data.trace, null, 4));
             }


### PR DESCRIPTION
Using .length on a property that doesn't exist will throw an error. This PR changed to Object.hasOwnProperty().