### PR TITLE
Connection timeout fix

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -243,8 +243,13 @@ switch ($action) {
         $parts = $turnitintooltwoassignment->get_parts();
 
         foreach ($parts as $part) {
-            $i = 0;
-            $turnitintooltwoassignment->get_submission_ids_from_tii($part, false);
+            $i = 0;            
+            try {
+                $turnitintooltwoassignment->get_submission_ids_from_tii($part, false);
+            }  catch (Exception $e) {
+                echo json_encode( array('success' => false) );
+                break 2;
+            }
             $total = count($_SESSION["TiiSubmissions"][$part->id]);
 
             while ($i < $total) {
@@ -280,7 +285,13 @@ switch ($action) {
             $istutor = (has_capability('mod/turnitintooltwo:grade', context_module::instance($cm->id))) ? true : false;
 
             if ($updatefromtii && $start == 0) {
-                $turnitintooltwoassignment->get_submission_ids_from_tii($parts[$partid]);
+                try {
+                    $turnitintooltwoassignment->get_submission_ids_from_tii($parts[$partid]);
+                }  catch (Exception $e) {
+                    $return["aaData"] = '';
+                    echo json_encode($return);
+                    break;
+                }
                 $total = count($_SESSION["TiiSubmissions"][$partid]);
             }
 

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1635,7 +1635,7 @@ class turnitintooltwo_assignment {
             $_SESSION["TiiSubmissions"][$part->id] = $findsubmission->getSubmissionIds();
 
         } catch (Exception $e) {
-            $turnitincomms->handle_exceptions($e, 'tiisubmissionsgeterror', false);
+            $turnitincomms->handle_exceptions($e, 'tiisubmissionsgeterror');
         }
     }
 


### PR DESCRIPTION
Hi all!

I made a fix for this outstanding issue:
https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/290

Requirement: Prevent turnitintooltwo cron task from creating multiple connections if the turnitin server is not responding.

Solution: throwing an error/exception and stopping the task execution 
Implementation: using the built-in exceptions handling of the turnitintooltwo plugin (turnitintooltwo_comms::handle_exceptions) to minimise the impact of the fix.

This will ensure the task is not proceeding further if the turntin server is not responding (in 120s) and that no performance is lost due to the multiple connection attempts and just one unsuccessful attempt to connect to the Turnitin server will stop the cron task execution.

Also, this way, multiple occurrences of the error will additionally delay the task execution by the Moodle cron system (see https://docs.moodle.org/dev/Task_API#Failures for more info).

No changes to the actual cron task have been made, this means that it will fail the same way it does so far, just not affecting the performance of the website.

Happy coding!
Cheers,
Johnny
