### PR TITLE
#408: Add calendar events to the myoverview block

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -848,6 +848,8 @@ class turnitintooltwo_assignment {
     public function create_event($toolid, $partname, $duedate) {
         global $CFG;
 
+        require_once($CFG->dirroot . '/calendar/lib.php');
+
         $properties = new stdClass();
         $properties->name = $this->turnitintooltwo->name . ' - ' . $partname;
         $intro = strip_pluginfile_content($this->turnitintooltwo->intro);
@@ -858,9 +860,11 @@ class turnitintooltwo_assignment {
         $properties->userid = 0;
         $properties->modulename = 'turnitintooltwo';
         $properties->instance = $toolid;
+        $properties->type = CALENDAR_EVENT_TYPE_ACTION;
         $properties->eventtype = 'due';
         $properties->timestart = $duedate;
         $properties->timeduration = 0;
+        $properties->timesort = $duedate;
 
         require_once($CFG->dirroot.'/calendar/lib.php');
         $event = new calendar_event($properties);
@@ -1296,6 +1300,7 @@ class turnitintooltwo_assignment {
 
                 $event->name = $this->turnitintooltwo->name." - ".$partdetails->partname;
                 $event->timestart = $partdetails->dtdue;
+                $event->timesort = $partdetails->dtdue;
                 $event->userid = $USER->id;
                 $DB->update_record('event', $event);
             }


### PR DESCRIPTION
From #407 

Add calendar events to the [myoverview](https://docs.moodle.org/33/en/Course_overview) block.

<img width="650" alt="screen shot 2018-01-02 at 3 57 14 pm" src="https://user-images.githubusercontent.com/2814676/34475310-cb751618-efda-11e7-9dbe-59732bb81929.png">

<img width="652" alt="screen shot 2018-01-02 at 3 57 26 pm" src="https://user-images.githubusercontent.com/2814676/34475343-2999e17e-efdb-11e7-9b62-3a9d4ab6db94.png">