### PR TITLE
Fix send message and some minor fixes.

### DIFF
--- a/classes/digitalreceipt/instructor_message.php
+++ b/classes/digitalreceipt/instructor_message.php
@@ -69,10 +69,7 @@ class instructor_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
-
-        if ($CFG->branch >= 32) {
-            $eventdata->courseid = $courseid;
-        }
+        $eventdata->courseid          = $courseid;
 
         foreach ($instructors as $instructor) {
 

--- a/classes/digitalreceipt/receipt_message.php
+++ b/classes/digitalreceipt/receipt_message.php
@@ -46,10 +46,7 @@ class receipt_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
-
-        if ($CFG->branch >= 32) {
-            $eventdata->courseid = $courseid;
-        }
+        $eventdata->courseid          = $courseid;
 
         message_send($eventdata);
     }

--- a/classes/nonsubmitters/nonsubmitters_message.php
+++ b/classes/nonsubmitters/nonsubmitters_message.php
@@ -24,7 +24,7 @@ class nonsubmitters_message {
      * @param string $message
      * @return void
      */
-    public function send_message($userid, $subject, $message) {
+    public function send_message($userid, $subject, $message, $courseid) {
         global $CFG;
 
         // Pre 2.9 does not have \core\message\message()
@@ -44,6 +44,7 @@ class nonsubmitters_message {
         $eventdata->fullmessagehtml   = $message;
         $eventdata->smallmessage      = '';
         $eventdata->notification      = 1; // This is only set to 0 for personal messages between users.
+        $eventdata->courseid          = $courseid;
 
         message_send($eventdata);
     }

--- a/mod_form.php
+++ b/mod_form.php
@@ -111,7 +111,8 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         }
 
         // Overwrite instructor default repository if admin is forcing repository setting.
-        $this->current->submitpapersto = turnitintooltwo_override_repository($this->current->submitpapersto);
+        $submitpapersto = (empty($this->current->submitpapersto)) ? 0 : $this->current->submitpapersto;
+        $this->current->submitpapersto = turnitintooltwo_override_repository($submitpapersto);
 
         $modulestring .= ') -->';
 

--- a/tests/unit/classes/nonsubmitters/nonsubmitters_message_test.php
+++ b/tests/unit/classes/nonsubmitters/nonsubmitters_message_test.php
@@ -29,7 +29,7 @@ class mod_turnitintooltwo_nonsubmitter_message_testcase extends advanced_testcas
         $user1 = $this->getDataGenerator()->create_user();
 
         // Send message to both instructors.
-        $nonsubmitters_message->send_message($user1->id, 'Nonsubmitters Subject', 'Nonsubmitters Message');
+        $nonsubmitters_message->send_message($user1->id, 'Nonsubmitters Subject', 'Nonsubmitters Message', 1);
 
         $messages = $sink->get_messages();
 

--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -1387,7 +1387,7 @@ class turnitintooltwo_view {
 
                 // Has the student accepted the EULA?
                 $eulaaccepted = $submissionuser->useragreementaccepted;
-                if ($submissionuser->useragreementaccepted == 0 && !$_SESSION["unit_test"]) {
+                if ($submissionuser->useragreementaccepted == 0 && !empty($_SESSION["unit_test"])) {
                     $eulaaccepted = $submissionuser->get_accepted_user_agreement();
                 }
             }

--- a/view.php
+++ b/view.php
@@ -425,12 +425,12 @@ if (!empty($action)) {
                 $nonsubmittedusers = array_diff_key((array)$allusers, (array)$suspendedusers, (array)$submittedusers);
                 foreach ($nonsubmittedusers as $nonsubmitteduser) {
                     // Send a message to the user's Moodle inbox with the digital receipt.
-                    $nonsubmitters->send_message($nonsubmitteduser->id, $subject, $message);
+                    $nonsubmitters->send_message($nonsubmitteduser->id, $subject, $message, $cm->course);
                 }
 
                 // Send a copy of message to the instructor if appropriate.
                 if (!empty($sendtoself)) {
-                    $nonsubmitters->send_message($USER->id, $subject, $message);
+                    $nonsubmitters->send_message($USER->id, $subject, $message, $cm->course);
                 }
 
                 $do = "emailsent";


### PR DESCRIPTION
Fixes send_message warnings for 3.2+/error in 3.5.
Fixes an issue where an undefined parameter would appear in the assignment setup page.
Fixes an issue where an undefined parameter would appear for a sudent who has not accepted the EULA.

Note: These would only appear with debugging on.