### PR TITLE
Issue #457: Fixed unit test breaking other plugins by enrolling…

### DIFF
--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -140,14 +140,6 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 		global $DB, $USER;
 		$this->resetAfterTest();
 		$_SESSION["unit_test"] = true;
-		
-		$USER->firstname = 'unit_test_first_654984';
-		$USER->lastname = 'unit_test_last_654984';
-		$USER->language = "en_US";
-		$USER->firstnamephonetic = "";
-		$USER->lastnamephonetic = "";
-		$USER->middlename = "";
-		$USER->alternatename = "";
 
 		// Set Turnitin account values in config as they are used in comms.
 		set_config('apiurl', 'http://invalid', 'turnitintooltwo');
@@ -166,7 +158,6 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 		$turnitintooltwouser = $testuser['turnitintooltwo_users'][0];
 		$moodleuser = $DB->get_record("turnitintooltwo_users", array("id" => $testuser['joins'][0]));
 
-		$this->enrol_test_user($USER->id, $course->id, "Learner");
 		$this->enrol_test_user($moodleuser->userid, $course->id, "Learner");
 
 		$partdetails = $this->make_test_parts('turnitintooltwo',$turnitintooltwoassignment->turnitintooltwo->id, 1);

--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -140,6 +140,14 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 		global $DB, $USER;
 		$this->resetAfterTest();
 		$_SESSION["unit_test"] = true;
+		
+		$USER->firstname = 'unit_test_first_654984';
+		$USER->lastname = 'unit_test_last_654984';
+		$USER->language = "en_US";
+		$USER->firstnamephonetic = "";
+		$USER->lastnamephonetic = "";
+		$USER->middlename = "";
+		$USER->alternatename = "";
 
 		// Set Turnitin account values in config as they are used in comms.
 		set_config('apiurl', 'http://invalid', 'turnitintooltwo');


### PR DESCRIPTION
non-existent user

The unit test was originally trying to enrolling the current logged in user but wasn't logged in as a user so $USER->id was 0 which wasn't achieving anything and breaking other plugins with enrol event observers.

