### PR TITLE
Ensure provider_testcase exists before testing privacy functionality

### DIFF
--- a/tests/unit/classes/privacy/provider_test.php
+++ b/tests/unit/classes/privacy/provider_test.php
@@ -32,6 +32,10 @@ global $CFG;
 
 require_once($CFG->dirroot . '/mod/turnitintooltwo/tests/unit/lib_test.php');
 
+if (!class_exists('\core_privacy\tests\provider_testcase')) {
+    return;
+}
+
 class mod_turnitintooltwo_privacy_provider_testcase extends \core_privacy\tests\provider_testcase {
 
     public function setup() {


### PR DESCRIPTION
Unit tests fail in Moodle before 3.3