### PR TITLE
Improvements to course overview timeline functionality.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -205,29 +205,7 @@ function turnitintooltwo_update_grades($turnitintooltwo, $userid = 0, $nullifnon
     $parts = $DB->get_records_select("turnitintooltwo_parts", " turnitintooltwoid = ? ",
                                         array($turnitintooltwo->id), 'id ASC');
     foreach ($parts as $part) {
-        $dbselect = " modulename = ? AND instance = ? AND courseid = ? AND name LIKE ? ";
-        // Moodle pre 2.5 on SQL Server errors here as queries weren't allowed on ntext fields, the relevant fields
-        // are nvarchar from 2.6 onwards so we have to cast the relevant fields in pre 2.5 SQL Server setups.
-        if ($CFG->branch <= 25 && $CFG->dbtype == "sqlsrv") {
-            $dbselect = " CAST(modulename AS nvarchar(max)) = ? AND instance = ?
-                            AND courseid = ? AND CAST(name AS nvarchar(max)) = ? ";
-        }
-
-        try {
-            // Update event for assignment part.
-            if ($event = $DB->get_record_select("event", $dbselect,
-                                        array('turnitintooltwo', $turnitintooltwo->id,
-                                                    $turnitintooltwo->course, '% - '.$part->partname))) {
-                $updatedevent = new stdClass();
-                $updatedevent->id = $event->id;
-                $updatedevent->userid = $USER->id;
-                $updatedevent->name = $turnitintooltwo->name." - ".$part->partname;
-
-                $DB->update_record('event', $updatedevent);
-            }
-        } catch (Exception $e) {
-            turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);
-        }
+        turnitintooltwo_update_event($turnitintooltwo, $part, true);
     }
 }
 
@@ -521,6 +499,7 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
             $part->submitted = 0;
 
             turnitintooltwo_reset_part_update($part, $i);
+            turnitintooltwo_update_event($turnitintooltwoassignment->turnitintooltwo, $part);
 
             if (!$DB->delete_records('turnitintooltwo_submissions', array('submission_part' => $partid))) {
                 turnitintooltwo_print_error('submissiondeleteerror', 'turnitintooltwo', null, null, __FILE__, __LINE__);
@@ -1889,4 +1868,49 @@ function mod_turnitintooltwo_get_availability_status($data, $checkcapability = f
     }
 
     return array($open, $warnings);
+}
+
+/**
+ * Update a Moodle event based on passed in details.
+ *
+ * @param  object  $turnitintooltwo    The turnitintooltwo assignment object.
+ * @param  object  $part               The name of the part we are updating.
+ * @param  boolean $courseparam        True if we wish to include the course field in our query.
+ * @param  boolean $convertEvent       True if we are converting the event from assignment page load.
+ */
+function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = false, $convertEvent = false) {
+    global $DB, $CFG, $USER;
+
+    // Create the SQL depending on whether we need to check the course parameter.
+    $dbselect = " modulename = ? AND instance = ? AND name LIKE ? ";
+    $dbparams = array('turnitintooltwo', $turnitintooltwo->id, '% - '.$part->partname);
+    if ($courseparam) {
+        $dbselect .= "AND courseid = ? ";
+        $dbparams[] = $turnitintooltwo->course;
+    }
+    try {
+        // Update event for assignment part.
+        if ($event = $DB->get_record_select("event", $dbselect, $dbparams)) {
+            $updatedevent = new stdClass();
+            $updatedevent->id = $event->id;
+            $updatedevent->userid = $USER->id;
+            $updatedevent->name = $turnitintooltwo->name." - ".$part->partname;
+            $updatedevent->timestart = $part->dtdue;
+
+            if ($CFG->branch >= 33) {
+                $updatedevent->timesort = $part->dtdue;
+                $updatedevent->type = 1;
+
+                if (($convertEvent) && ($event->type == 0)) {
+                    $DB->update_record('event', $updatedevent);
+                    return;
+                }
+            }
+
+            $DB->update_record('event', $updatedevent);
+            return;
+        }
+    } catch (Exception $e) {
+        turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);
+    }
 }

--- a/lib.php
+++ b/lib.php
@@ -1876,9 +1876,9 @@ function mod_turnitintooltwo_get_availability_status($data, $checkcapability = f
  * @param  object  $turnitintooltwo    The turnitintooltwo assignment object.
  * @param  object  $part               The name of the part we are updating.
  * @param  boolean $courseparam        True if we wish to include the course field in our query.
- * @param  boolean $convertEvent       True if we are converting the event from assignment page load.
+ * @param  boolean $convertevent       True if we are converting the event from assignment page load.
  */
-function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = false, $convertEvent = false) {
+function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = false, $convertevent = false) {
     global $DB, $CFG, $USER;
 
     // Create the SQL depending on whether we need to check the course parameter.
@@ -1903,7 +1903,7 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
                 $updatedevent->type = 1;
 
                 // No need to continue updating on this occasion if we have a new event type already.
-                if (($convertEvent) && ($event->type == 1)) {
+                if (($convertevent) && ($event->type == 1)) {
                     return;
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -1891,6 +1891,7 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
     try {
         // Update event for assignment part.
         if ($event = $DB->get_record_select("event", $dbselect, $dbparams)) {
+            // Update the event.
             $updatedevent = new stdClass();
             $updatedevent->id = $event->id;
             $updatedevent->userid = $USER->id;
@@ -1901,14 +1902,13 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
                 $updatedevent->timesort = $part->dtdue;
                 $updatedevent->type = 1;
 
-                if (($convertEvent) && ($event->type == 0)) {
-                    $DB->update_record('event', $updatedevent);
+                // No need to continue updating on this occasion if we have a new event type already.
+                if (($convertEvent) && ($event->type == 1)) {
                     return;
                 }
             }
 
             $DB->update_record('event', $updatedevent);
-            return;
         }
     } catch (Exception $e) {
         turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -406,9 +406,9 @@ class mod_lib_testcase extends test_lib {
 
         if ($CFG->branch >= 33) {
             $this->assertEquals(1, $response->type);
+            $this->assertNotEquals(0, $response->timesort);
         }
         $this->assertNotEquals(0, $response->timestart);
-        $this->assertNotEquals(0, $response->timesort);
 
         // Reset event values.
         $DB->update_record('event', $updatedevent);
@@ -419,9 +419,9 @@ class mod_lib_testcase extends test_lib {
 
         if ($CFG->branch >= 33) {
             $this->assertEquals(1, $response->type);
+            $this->assertNotEquals(0, $response->timesort);
         }
         $this->assertNotEquals(0, $response->timestart);
-        $this->assertNotEquals(0, $response->timesort);
 
         // Reset event values.
         $DB->update_record('event', $updatedevent);
@@ -432,9 +432,9 @@ class mod_lib_testcase extends test_lib {
 
         if ($CFG->branch >= 33) {
             $this->assertEquals(1, $response->type);
+            $this->assertNotEquals(0, $response->timesort);
         }
         $this->assertNotEquals(0, $response->timestart);
-        $this->assertNotEquals(0, $response->timesort);
 
         // We can check that a second call to convert an event will not update the event by resetting only the timestart value and checking it is not updated,
         $updatedevent = new stdClass();

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -426,26 +426,30 @@ class mod_lib_testcase extends test_lib {
         // Reset event values.
         $DB->update_record('event', $updatedevent);
 
-        // Check that we can convert an old event to a new event.
-        turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
-        $response = $DB->get_record("event", array("id" => $event->id));
+        // This test is only relevant to 3.3+;
 
         if ($CFG->branch >= 33) {
-            $this->assertEquals(1, $response->type);
-            $this->assertNotEquals(0, $response->timesort);
+            // Check that we can convert an old event to a new event.
+            turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
+            $response = $DB->get_record("event", array("id" => $event->id));
+
+            if ($CFG->branch >= 33) {
+                $this->assertEquals(1, $response->type);
+                $this->assertNotEquals(0, $response->timesort);
+            }
+            $this->assertNotEquals(0, $response->timestart);
+
+            // We can check that a second call to convert an event will not update the event by resetting only the timestart value and checking it is not updated,
+            $updatedevent = new stdClass();
+            $updatedevent->id = $event->id;
+            $updatedevent->timestart = 0;
+            $DB->update_record('event', $updatedevent);
+
+            // This call should not update values, so timestart should still equal 0.
+            turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
+            $response = $DB->get_record("event", array("id" => $event->id));
+
+            $this->assertEquals(0, $response->timestart);
         }
-        $this->assertNotEquals(0, $response->timestart);
-
-        // We can check that a second call to convert an event will not update the event by resetting only the timestart value and checking it is not updated,
-        $updatedevent = new stdClass();
-        $updatedevent->id = $event->id;
-        $updatedevent->timestart = 0;
-        $DB->update_record('event', $updatedevent);
-
-        // This call should not update values, so timesort should still equal 0.
-        turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
-        $response = $DB->get_record("event", array("id" => $event->id));
-
-        $this->assertEquals(0, $response->timestart);
     }
 }

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -404,7 +404,9 @@ class mod_lib_testcase extends test_lib {
         turnitintooltwo_update_event($turnitintooltwo, $part);
         $response = $DB->get_record("event", array("id" => $event->id));
 
-        $this->assertEquals(1, $response->type);
+        if ($CFG->branch >= 33) {
+            $this->assertEquals(1, $response->type);
+        }
         $this->assertNotEquals(0, $response->timestart);
         $this->assertNotEquals(0, $response->timesort);
 
@@ -415,7 +417,9 @@ class mod_lib_testcase extends test_lib {
         turnitintooltwo_update_event($turnitintooltwo, $part, true);
         $response = $DB->get_record("event", array("id" => $event->id));
 
-        $this->assertEquals(1, $response->type);
+        if ($CFG->branch >= 33) {
+            $this->assertEquals(1, $response->type);
+        }
         $this->assertNotEquals(0, $response->timestart);
         $this->assertNotEquals(0, $response->timesort);
 
@@ -426,7 +430,9 @@ class mod_lib_testcase extends test_lib {
         turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
         $response = $DB->get_record("event", array("id" => $event->id));
 
-        $this->assertEquals(1, $response->type);
+        if ($CFG->branch >= 33) {
+            $this->assertEquals(1, $response->type);
+        }
         $this->assertNotEquals(0, $response->timestart);
         $this->assertNotEquals(0, $response->timesort);
 

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -368,4 +368,78 @@ class mod_lib_testcase extends test_lib {
         $this->assertArrayHasKey('notopenyet', $warnings);
         $this->assertArrayHasKey('expired', $warnings);
     }
+
+    public function test_turnitintooltwo_update_event() {
+        global $DB, $CFG;
+
+        $this->resetAfterTest();
+
+        $turnitintooltwoassignment = $this->make_test_tii_assignment();
+        $turnitintooltwo = $turnitintooltwoassignment->turnitintooltwo;
+        $this->make_test_parts("turnitintooltwo", $turnitintooltwo->id, 1);
+        $part = $DB->get_record('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id));
+
+        $turnitintooltwo->intro = "Intro";
+        $part->dtdue = time();
+
+        // Create an event.
+        $assignment = new turnitintooltwo_assignment(1, $turnitintooltwo);
+        $assignment->create_event($turnitintooltwo->id, $part->partname, time());
+
+        $event = $DB->get_record_select("event", " modulename = ? AND instance = ? AND name LIKE ? ",
+            array('turnitintooltwo', $turnitintooltwo->id, '% - '.$part->partname));
+
+        // Reset event values so we can then go on to check if our method will update them.
+        $updatedevent = new stdClass();
+        $updatedevent->id = $event->id;
+        $updatedevent->userid = 0;
+        $updatedevent->timestart = 0;
+        if ($CFG->branch >= 33) {
+            $updatedevent->timesort = 0;
+            $updatedevent->type = 0;
+        }
+        $DB->update_record('event', $updatedevent);
+
+        // Check the event will update for a standard call to the method.
+        turnitintooltwo_update_event($turnitintooltwo, $part);
+        $response = $DB->get_record("event", array("id" => $event->id));
+
+        $this->assertEquals(1, $response->type);
+        $this->assertNotEquals(0, $response->timestart);
+        $this->assertNotEquals(0, $response->timesort);
+
+        // Reset event values.
+        $DB->update_record('event', $updatedevent);
+
+        // Check the event will update for a call to the method with an extra course parameter.
+        turnitintooltwo_update_event($turnitintooltwo, $part, true);
+        $response = $DB->get_record("event", array("id" => $event->id));
+
+        $this->assertEquals(1, $response->type);
+        $this->assertNotEquals(0, $response->timestart);
+        $this->assertNotEquals(0, $response->timesort);
+
+        // Reset event values.
+        $DB->update_record('event', $updatedevent);
+
+        // Check that we can convert an old event to a new event.
+        turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
+        $response = $DB->get_record("event", array("id" => $event->id));
+
+        $this->assertEquals(1, $response->type);
+        $this->assertNotEquals(0, $response->timestart);
+        $this->assertNotEquals(0, $response->timesort);
+
+        // We can check that a second call to convert an event will not update the event by resetting only the timestart value and checking it is not updated,
+        $updatedevent = new stdClass();
+        $updatedevent->id = $event->id;
+        $updatedevent->timestart = 0;
+        $DB->update_record('event', $updatedevent);
+
+        // This call should not update values, so timesort should still equal 0.
+        turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
+        $response = $DB->get_record("event", array("id" => $event->id));
+
+        $this->assertEquals(0, $response->timestart);
+    }
 }

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1292,22 +1292,7 @@ class turnitintooltwo_assignment {
 
         // Update existing events for this assignment part if title or due date changed.
         if ($fieldname == "partname" || $fieldname == "dtdue") {
-
-            $dbselect = " modulename = ? AND instance = ? AND name LIKE ? ";
-            // Moodle pre 2.5 on SQL Server errors here as queries weren't allowed on ntext fields, the relevant fields
-            // are nvarchar from 2.6 onwards so we have to cast the relevant fields in pre 2.5 SQL Server setups.
-            if ($CFG->branch <= 25 && $CFG->dbtype == "sqlsrv") {
-                $dbselect = " CAST(modulename AS nvarchar(max)) = ? AND instance = ? AND CAST(name AS nvarchar(max)) = ? ";
-            }
-
-            if ($event = $DB->get_record_select("event", $dbselect,
-                                                array('turnitintooltwo', $this->turnitintooltwo->id, $currenteventname))) {
-
-                $event->name = $this->turnitintooltwo->name." - ".$partdetails->partname;
-                $event->timestart = $partdetails->dtdue;
-                $event->userid = $USER->id;
-                $DB->update_record('event', $event);
-            }
+            turnitintooltwo_update_event($this->turnitintooltwo, $partdetails);
         }
 
         // Update grade settings.

--- a/view.php
+++ b/view.php
@@ -732,6 +732,13 @@ switch ($do) {
             unset($_SESSION["digital_receipt"]);
         }
 
+        // Convert the course overview events to MDL33+ events if necessary.
+        if (($CFG->branch >= 33) && ($istutor)) {
+            foreach ($parts as $part) {
+                turnitintooltwo_update_event($turnitintooltwoassignment->turnitintooltwo, $part, null, true);
+            }
+        }
+
         // Initialise inbox, if a student is logged in then populate it also incase they have no javascript.
         echo $turnitintooltwoview->init_submission_inbox($cm, $turnitintooltwoassignment, $parts, $turnitintooltwouser);
 


### PR DESCRIPTION
This pull request fixes three areas that were missed during the implementation of Moodle 3.3+ course overview support in the previous release:

- The date now updates when the due date is updated.
- The dates now update on a course reset if the reset is set to use new assignment dates.
- Previously created assignments will now update to use the new course overview functionality automatically when an instructor opens an assignment. (this allows for backwards compatibility with assignments created on older versions)

I've also removed some now redundant pre 2.6 code as the plugin requires a higher version of Moodle than that anyway.