### PR TITLE
Ensure the course section number is actually migrated.

### DIFF
--- a/classes/v1migration/v1migration.php
+++ b/classes/v1migration/v1migration.php
@@ -298,16 +298,13 @@ class v1migration {
         $coursemodule->instance = $turnitintooltwoid;
         $coursemodule->section = 0;
 
-        // Add Course module and get course section.
+        // Add Course module.
         $coursemodule->coursemodule = add_course_module($coursemodule);
 
-        if (is_callable('course_add_cm_to_section')) {
-            $sectionid = course_add_cm_to_section($coursemodule->course, $coursemodule->coursemodule, $coursemodule->section);
-        } else {
-            $sectionid = add_mod_to_section($coursemodule);
-        }
+        // Get the section for the V1 assignment.
+        $section = $DB->get_record('course_sections', array('course' => $courseid, 'id' => $this->cm->section), 'section');
+        course_add_cm_to_section($coursemodule->course, $coursemodule->coursemodule, $section->section);
 
-        $DB->set_field("course_modules", "section", $sectionid, array("id" => $coursemodule->coursemodule));
         rebuild_course_cache($coursemodule->coursemodule);
     }
 

--- a/tests/unit/classes/v1migration/v1migration_test.php
+++ b/tests/unit/classes/v1migration/v1migration_test.php
@@ -301,14 +301,22 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
         $course = $this->getDataGenerator()->create_course();
 
         // Create Assignment.
+        $v1assignmenttitle = "Test ".uniqid();
+        $v1assignment = $this->make_test_assignment($course->id, 'turnitintool', $v1assignmenttitle);
+        $v1migration = new v1migration($course->id, $v1assignment);
+
+        // Get the section for the V1 assignment.
+        $v1cm = get_coursemodule_from_instance('turnitintool', $v1assignment->id);
+
+        // Create V2 Assignment.
         $v2assignment = $this->make_test_assignment($course->id, 'turnitintooltwo');
-        $v1migration = new v1migration($course->id, $v2assignment);
 
         $v1migration->setup_v2_module($course->id, $v2assignment->id);
 
         // Test that assignment has been assigned a course section.
-        $cm = get_coursemodule_from_instance('turnitintooltwo', $v2assignment->id);
-        $this->assertNotEquals(0, $cm->section);
+        $v2cm = get_coursemodule_from_instance('turnitintooltwo', $v2assignment->id);
+
+        $this->assertEquals($v1cm->section, $v2cm->section);
     }
 
     /**
@@ -701,6 +709,18 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
 
         $course = $this->getDataGenerator()->create_course();
 
+        // Link course to Turnitin.
+        $courselink = new stdClass();
+        $courselink->courseid = $course->id;
+        $courselink->ownerid = 0;
+        $courselink->turnitin_ctl = "Test Course";
+        $courselink->turnitin_cid = 0;
+        $DB->insert_record('turnitintool_courses', $courselink);
+
+        $v1assignmenttitle = "Test ".uniqid();
+        $v1assignment = $this->make_test_assignment($course->id, 'turnitintool', $v1assignmenttitle);
+        $v1migration = new v1migration($course->id, $v1assignment);
+
         // create a user and enrol them on the course.
         $student = $this->getDataGenerator()->create_user();
         $studentrole = $DB->get_record('role', array('shortname' => 'student'));
@@ -710,7 +730,6 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
         $v2assignmenttitle = "Test Assignment";
         $v2assignment = $this->make_test_assignment($course->id, 'turnitintooltwo', $v2assignmenttitle, 10);
 
-        $v1migration = new v1migration($course->id, $v2assignment);
         $v1migration->setup_v2_module($course->id, $v2assignment->id);
 
         // Set and get the grades for this assignment.
@@ -744,12 +763,12 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
         // Create V1 Assignment.
         $v1assignmenttitle = "Test Assignment";
         $v1assignment = $this->make_test_assignment($course->id, 'turnitintool', $v1assignmenttitle);
+        $v1migration = new v1migration($course->id, $v1assignment);
 
         // Create V2 Assignment.
         $v2assignmenttitle = "Test Assignment";
         $v2assignment = $this->make_test_assignment($course->id, 'turnitintooltwo', $v2assignmenttitle, 10);
 
-        $v1migration = new v1migration($course->id, $v2assignment);
         $v1migration->setup_v2_module($course->id, $v2assignment->id);
 
         $this->make_test_grade("turnitintooltwo", $v2assignment->id, $course->id, 1, 10);


### PR DESCRIPTION
This fixes a bug where the course section where a V1 assignment belongs is not kept when migrating the assignment to V2. Unit tests have been updated to work with the change.