### PR TITLE
Ignore parts deletion flag (untested)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -336,8 +336,7 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
     }
 
     foreach ($turnitintooltwos as $turnitintooltwo) {
-        if (!$parts = $DB->get_records('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id,
-                                                                            'deleted' => 0))) {
+        if (!$parts = $DB->get_records('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id))) {
             turnitintooltwo_print_error('partgeterror', 'turnitintooltwo', null, null, __FILE__, __LINE__);
             exit();
         }

--- a/mod_form.php
+++ b/mod_form.php
@@ -78,7 +78,7 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
             $this->turnitintooltwo = $DB->get_record("turnitintooltwo", array("id" => $this->_cm->instance));
             $parts = $DB->get_records("turnitintooltwo_parts",
-                                        array("turnitintooltwoid" => $this->_cm->instance, "deleted" => 0), 'id');
+                                        array("turnitintooltwoid" => $this->_cm->instance), 'id');
 
             $i = 0;
             foreach ($parts as $part) {


### PR DESCRIPTION
Turnitin assignment v2 isn't supposed to respect the parts deletion flag any more?  This patch is intended to ignore the parts deletion flag in a couple of places where it is still checked.
(I can't test it out though, so I don't really know if it's right.)