### PR TITLE
Create event if it does not exist when update has been called.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1791,14 +1791,15 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
         $dbparams[] = $turnitintooltwo->course;
     }
     try {
-        // Update event for assignment part.
+        // Create event data.
+        $updatedevent = new stdClass();
+        $updatedevent->userid = $USER->id;
+        $updatedevent->name = $turnitintooltwo->name." - ".$part->partname;
+        $updatedevent->timestart = $part->dtdue;
+
+        // Create/Update event for assignment part.
         if ($event = $DB->get_record_select("event", $dbselect, $dbparams)) {
-            // Update the event.
-            $updatedevent = new stdClass();
             $updatedevent->id = $event->id;
-            $updatedevent->userid = $USER->id;
-            $updatedevent->name = $turnitintooltwo->name." - ".$part->partname;
-            $updatedevent->timestart = $part->dtdue;
 
             if ($CFG->branch >= 33) {
                 $updatedevent->timesort = $part->dtdue;
@@ -1811,6 +1812,9 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
             }
 
             $DB->update_record('event', $updatedevent);
+        } else {
+            $turnitintooltwoassignment = new turnitintooltwo_assignment($turnitintooltwo->id);
+            $turnitintooltwoassignment->create_event($turnitintooltwo->id, $part->partname, $part->dtdue);
         }
     } catch (Exception $e) {
         turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -281,7 +281,8 @@ class mod_lib_testcase extends test_lib {
         $course = $this->getDataGenerator()->create_course();
 
         $turnitintooltwoassignment = $this->make_test_tii_assignment();
-        $cmid = $this->make_test_module($turnitintooltwoassignment->turnitintooltwo->course,'turnitintooltwo', $turnitintooltwoassignment->turnitintooltwo->id);
+        $cmid = $this->make_test_module($turnitintooltwoassignment->turnitintooltwo->course,
+            'turnitintooltwo', $turnitintooltwoassignment->turnitintooltwo->id);
         $context = context_module::instance($cmid);
         $cm = $DB->get_record("course_modules", array('id' => $cmid));
 
@@ -427,7 +428,6 @@ class mod_lib_testcase extends test_lib {
         $DB->update_record('event', $updatedevent);
 
         // This test is only relevant to 3.3+;
-
         if ($CFG->branch >= 33) {
             // Check that we can convert an old event to a new event.
             turnitintooltwo_update_event($turnitintooltwo, $part, null, true);
@@ -439,7 +439,8 @@ class mod_lib_testcase extends test_lib {
             }
             $this->assertNotEquals(0, $response->timestart);
 
-            // We can check that a second call to convert an event will not update the event by resetting only the timestart value and checking it is not updated,
+            // We can check that a second call to convert an event will not update the event by resetting only the
+            // timestart value and checking it is not updated,
             $updatedevent = new stdClass();
             $updatedevent->id = $event->id;
             $updatedevent->timestart = 0;
@@ -451,5 +452,14 @@ class mod_lib_testcase extends test_lib {
 
             $this->assertEquals(0, $response->timestart);
         }
+
+        // Remove event and check that the update event method will create one if one doesn't exist.
+        $DB->delete_records('event', array('id' => $updatedevent->id));
+        $this->assertEquals(0, $DB->count_records('event', array('id' => $updatedevent->id)));
+
+        turnitintooltwo_update_event($turnitintooltwo, $part);
+        $dbselect = " name = ? ";
+        $dbparams = array($turnitintooltwo->name." - ".$part->partname);
+        $this->assertEquals(1, $DB->count_records_select('event', $dbselect, $dbparams));
     }
 }


### PR DESCRIPTION
Update event is called but it's possible that the no event may exist as it could have been deleted during e.g. course reset. This PR creates an event if necessary.