### PR TITLE
New capability for admins to prevent deletions

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -55,6 +55,16 @@ $capabilities = array(
         )
     ),
 
+    'mod/turnitintooltwo:delete' => array(
+
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'legacy' => array(
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW
+        )
+    ),
+
     'mod/turnitintooltwo:grade' => array(
 
         'captype' => 'write',


### PR DESCRIPTION
This is a proposal to allow Moodle admins to choose whether teachers can delete Turnitin activities or not, so they can prevent accidental deletions.