### PR TITLE
The coursecat class is deprecated in Moodle 3.6 #558

### DIFF
--- a/extras.php
+++ b/extras.php
@@ -103,15 +103,7 @@ switch ($cmd) {
 
         $output .= $OUTPUT->box($coursesearchform, 'generalbox', 'course_search_options');
 
-        $displaylist = array();
-        $parentlist = array();
-        require_once($CFG->dirroot."/course/lib.php");
-        if (file_exists($CFG->libdir.'/coursecatlib.php')) {
-            require_once($CFG->libdir.'/coursecatlib.php');
-            $displaylist = coursecat::make_categories_list('');
-        } else {
-            make_categories_list($displaylist, $parentlist, '');
-        }
+        $displaylist = core_course_category::make_categories_list('');
 
         $categoryselectlabel = html_writer::label(get_string('selectcoursecategory', 'turnitintooltwo'), 'create_course_category');
         $categoryselect = html_writer::select($displaylist, 'create_course_category', '', array(),

--- a/lib.php
+++ b/lib.php
@@ -1481,16 +1481,7 @@ function turnitintooltwo_show_browser_new_course_form() {
 
     $elements = array();
     $elements[] = array('header', 'create_course_fieldset', get_string('createcourse', 'turnitintooltwo'));
-    $displaylist = array();
-    $parentlist = array();
-    require_once($CFG->dirroot."/course/lib.php");
-
-    if (file_exists($CFG->libdir.'/coursecatlib.php')) {
-        require_once($CFG->libdir.'/coursecatlib.php');
-        $displaylist = coursecat::make_categories_list('');
-    } else {
-        make_categories_list($displaylist, $parentlist, '');
-    }
+    $displaylist = core_course_category::make_categories_list('');
 
     $elements[] = array('select', 'coursecategory', get_string('category'), '', $displaylist);
     $elements[] = array('text', 'coursename', get_string('coursetitle', 'turnitintooltwo'), '');

--- a/settings_extras.php
+++ b/settings_extras.php
@@ -328,7 +328,6 @@ switch ($cmd) {
         $output .= $OUTPUT->box($coursesearchform, 'generalbox', 'course_search_options');
 
         $displaylist = core_course_category::make_categories_list('');
-        $parentlist = array();
 
         $categoryselectlabel = html_writer::label(get_string('selectcoursecategory', 'turnitintooltwo'),
                                                     'create_course_category');


### PR DESCRIPTION
Completed the fix for deprecated calls in https://github.com/turnitin/moodle-mod_turnitintooltwo/commit/809b930564bebdcacd8dd93283a711185ecf71ef#diff-44376c7e47071c0c82052d33d5f0ef45R330

Resolves https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/558