### PR TITLE
Issue #605: cron fail on adhoc task course_delete_modules

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -975,7 +975,7 @@ class turnitintooltwo_assignment {
 
         // Get the Moodle Turnitintool (Assignment) Object.
         if (!$turnitintooltwo = $DB->get_record("turnitintooltwo", array("id" => $id))) {
-            return false;
+            return true;
         }
 
         // Get Current Moodle Turnitin Tool parts and delete them.


### PR DESCRIPTION
This should resolve issue #605 

when turnitintooltwo can't find the record on mdl_turnitintooltwo because it has been deleted (maybe due to race condition or some other errors) , it should return true just like Moodle does here:
https://github.com/moodle/moodle/blob/master/course/lib.php#L1141-L1142
