### PR TITLE
Add filter support to instructor message

### DIFF
--- a/classes/digitalreceipt/instructor_message.php
+++ b/classes/digitalreceipt/instructor_message.php
@@ -38,7 +38,7 @@ class instructor_message {
         $message->submission_date = $input['submission_date'];
         $message->submission_id = $input['submission_id'];
 
-        return get_string('receipt_instructor_copy', 'turnitintooltwo', $message);
+        return format_string(get_string('receipt_instructor_copy', 'turnitintooltwo', $message));
     }
 
     /**


### PR DESCRIPTION
We've detected that the messages send by Turnitin to instructors don't apply the Moodle filters (we use filter_multilang2, but it may happen also with order filters), this change fixes that.