### PR TITLE
Add filter support to submitter message

### DIFF
--- a/classes/digitalreceipt/receipt_message.php
+++ b/classes/digitalreceipt/receipt_message.php
@@ -70,6 +70,6 @@ class receipt_message {
         $message->submission_date = $input['submission_date'];
         $message->submission_id = $input['submission_id'];
 
-        return get_string('digital_receipt_message', 'turnitintooltwo', $message);
+        return format_string(get_string('digital_receipt_message', 'turnitintooltwo', $message));
     }
 }


### PR DESCRIPTION
We've detected that the messages send by Turnitin to submitters don't apply the Moodle filters (we use filter_multilang2, but it may happen also with order filters), this change fixes that.