### PR TITLE
Fixes PHP8 compatibility

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -119,10 +119,10 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
         $modulestring .= ') -->';
 
-        $this->show_form($instructorrubrics, $sharedrubrics, $modulestring, $course->turnitin_cid);
+        $this->show_form($instructorrubrics, $sharedrubrics, $course->turnitin_cid, $modulestring);
     }
 
-    public function show_form($instructorrubrics, $sharedrubrics, $modulestring = '', $tiicourseid) {
+    public function show_form($instructorrubrics, $sharedrubrics, $tiicourseid, $modulestring = '') {
         global $CFG, $OUTPUT, $COURSE, $PAGE, $DB;
         $PAGE->requires->string_for_js('changerubricwarning', 'turnitintooltwo');
         $PAGE->requires->string_for_js('closebutton', 'turnitintooltwo');

--- a/sdk/lti.class.php
+++ b/sdk/lti.class.php
@@ -610,7 +610,7 @@ class LTI extends OAuthSimple {
      *
      * @return string
      */
-    public function __getLastResponse() {
+    public function getLastResponse() {
         return $this->lastresponse;
     }
 

--- a/sdk/lti.class.php
+++ b/sdk/lti.class.php
@@ -594,7 +594,7 @@ class LTI extends OAuthSimple {
      *
      * @return string
      */
-    public function __getLastRequest() {
+    public function getLastRequest() {
         return $this->lastrequest;
     }
 

--- a/sdk/lti.class.php
+++ b/sdk/lti.class.php
@@ -618,7 +618,7 @@ class LTI extends OAuthSimple {
      *
      * @param string $lastresponse
      */
-    private function __setLastResponse( $lastresponse ) {
+    private function setLastResponse( $lastresponse ) {
         $this->lastresponse = $lastresponse;
     }
 
@@ -970,7 +970,7 @@ class LTI extends OAuthSimple {
         }
 
         $this->setLastRequest( print_r( $params, true ) );
-        $this->__setLastResponse( $result );
+        $this->setLastResponse( $result );
 
         curl_close($ch);
         return $response;

--- a/sdk/lti.class.php
+++ b/sdk/lti.class.php
@@ -602,7 +602,7 @@ class LTI extends OAuthSimple {
      *
      * @param string $lastrequest
      */
-    private function __setLastRequest( $lastrequest ) {
+    private function setLastRequest( $lastrequest ) {
         $this->lastrequest = $lastrequest;
     }
 
@@ -969,7 +969,7 @@ class LTI extends OAuthSimple {
             $response = $result;
         }
 
-        $this->__setLastRequest( print_r( $params, true ) );
+        $this->setLastRequest( print_r( $params, true ) );
         $this->__setLastResponse( $result );
 
         curl_close($ch);

--- a/sdk/response.class.php
+++ b/sdk/response.class.php
@@ -36,9 +36,9 @@ class Response {
         $this->domobject = new DomDocument();
         $this->requestdomobject = new DomDocument();
         $logger = new TurnitinLogger( $soap->getLogPath() );
-        if ( $logger ) $logger->logInfo( $soap->getHttpHeaders() . PHP_EOL . $soap->__getLastRequest() );
-        if ( $soap->getDebug() ) $this->outputDebug( $soap->__getLastRequest(), 'Request Message', $soap->getHttpHeaders() );
-        @$this->requestdomobject->loadXML( $soap->__getLastRequest() );
+        if ( $logger ) $logger->logInfo( $soap->getHttpHeaders() . PHP_EOL . $soap->getLastRequest() );
+        if ( $soap->getDebug() ) $this->outputDebug( $soap->getLastRequest(), 'Request Message', $soap->getHttpHeaders() );
+        @$this->requestdomobject->loadXML( $soap->getLastRequest() );
         if ( $logger ) $logger->logInfo( $soap->__getLastResponse() );
         if ( $soap->getDebug() ) $this->outputDebug( $soap->__getLastResponse(), 'Response Message' );
         if ( ($load = @$this->domobject->loadXML( $soap->__getLastResponse() )) === false ) {

--- a/sdk/response.class.php
+++ b/sdk/response.class.php
@@ -39,9 +39,9 @@ class Response {
         if ( $logger ) $logger->logInfo( $soap->getHttpHeaders() . PHP_EOL . $soap->getLastRequest() );
         if ( $soap->getDebug() ) $this->outputDebug( $soap->getLastRequest(), 'Request Message', $soap->getHttpHeaders() );
         @$this->requestdomobject->loadXML( $soap->getLastRequest() );
-        if ( $logger ) $logger->logInfo( $soap->__getLastResponse() );
-        if ( $soap->getDebug() ) $this->outputDebug( $soap->__getLastResponse(), 'Response Message' );
-        if ( ($load = @$this->domobject->loadXML( $soap->__getLastResponse() )) === false ) {
+        if ( $logger ) $logger->logInfo( $soap->getLastResponse() );
+        if ( $soap->getDebug() ) $this->outputDebug( $soap->getLastResponse(), 'Response Message' );
+        if ( ($load = @$this->domobject->loadXML( $soap->getLastResponse() )) === false ) {
             throw new TurnitinSDKException( 'responsexmlerror', 'XML Response could not be parsed', $soap->getLogPath() );
         }
         $this->setMessageId( @$this->domobject->getElementsByTagName( 'imsx_messageIdentifier' )->item(0)->nodeValue );


### PR DESCRIPTION
Fixes PHP8 deprecation warning
see https://php.watch/versions/8.0/deprecate-required-param-after-optional

PHP has reserved all method names with a double underscore prefix for future use.
see https://www.php.net/manual/en/language.oop5.magic.php