### PR TITLE
Modify turnitintooltwo to not serve files directly

### DIFF
--- a/jquery/jquery.dataTables.css
+++ b/jquery/jquery.dataTables.css
@@ -47,19 +47,19 @@ table.dataTable thead .sorting_desc_disabled {
   background-position: center right;
 }
 table.dataTable thead .sorting {
-  background-image: url("../../../mod/turnitintooltwo/pix/sort_both.png");
+  background-image: url("/pluginfile.php/1/mod_turnitintooltwo/direct/pix/sort_both.png");
 }
 table.dataTable thead .sorting_asc {
-  background-image: url("../../../mod/turnitintooltwo/pix/sort_asc.png");
+  background-image: url("/pluginfile.php/1/mod_turnitintooltwo/direct/pix/sort_asc.png");
 }
 table.dataTable thead .sorting_desc {
-  background-image: url("../../../mod/turnitintooltwo/pix/sort_desc.png");
+  background-image: url("/pluginfile.php/1/mod_turnitintooltwo/direct/pix/sort_desc.png");
 }
 table.dataTable thead .sorting_asc_disabled {
-  background-image: url("../../../mod/turnitintooltwo/pix/sort_asc_disabled.png");
+  background-image: url("/pluginfile.php/1/mod_turnitintooltwo/direct/pix/sort_asc_disabled.png");
 }
 table.dataTable thead .sorting_desc_disabled {
-  background-image: url("../../../mod/turnitintooltwo/pix/sort_desc_disabled.png");
+  background-image: url("/pluginfile.php/1/mod_turnitintooltwo/direct/pix/sort_desc_disabled.png");
 }
 table.dataTable tbody tr {
   background-color: #ffffff;

--- a/settings.php
+++ b/settings.php
@@ -63,9 +63,10 @@ if ($ADMIN->fulltree) {
     }
 
     $tabmenu = $turnitintooltwoview->draw_settings_menu('settings').
-                html_writer::tag('noscript', get_string('noscript', 'turnitintooltwo')).$librarywarning.
-                html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
-                                            "href" => $CFG->wwwroot."/mod/turnitintooltwo/styles.css"));
+                html_writer::tag('noscript', get_string('noscript', 'turnitintooltwo')).$librarywarning;
+
+    $cssurl = moodle_url::make_pluginfile_url(context_system::instance()->id, 'mod_turnitintooltwo', 'direct', null, '/', 'styles.css');
+    $PAGE->requires->css($cssurl);
 
     $currentsection = optional_param('section', '', PARAM_ALPHAEXT);
 

--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -58,18 +58,20 @@ class turnitintooltwo_view {
     public function load_page_components($hidebg = false) {
         global $PAGE;
 
+        $contextid = context_system::instance()->id;
+
         // Include CSS.
         if ($hidebg) {
-            $cssurl = new moodle_url('/mod/turnitintooltwo/css/hide_bg.css');
+            $cssurl = moodle_url::make_pluginfile_url($contextid, 'mod_turnitintooltwo', 'direct', null, '/css/', 'hide_bg.css');
             $PAGE->requires->css($cssurl);
         }
-        $cssurl = new moodle_url('/mod/turnitintooltwo/styles.css');
+        $cssurl = moodle_url::make_pluginfile_url($contextid, 'mod_turnitintooltwo', 'direct', null, '/', 'styles.css');
         $PAGE->requires->css($cssurl);
-        $cssurl = new moodle_url('/mod/turnitintooltwo/css/jquery-ui-1.8.4.custom.css');
+        $cssurl = moodle_url::make_pluginfile_url($contextid, 'mod_turnitintooltwo', 'direct', null, '/css/', 'jquery-ui-1.8.4.custom.css');
         $PAGE->requires->css($cssurl);
-        $cssurl = new moodle_url('/mod/turnitintooltwo/css/font-awesome.min.css');
+        $cssurl = moodle_url::make_pluginfile_url($contextid, 'mod_turnitintooltwo', 'direct', null, '/css/', 'font-awesome.min.css');
         $PAGE->requires->css($cssurl);
-        $cssurl = new moodle_url('/mod/turnitintooltwo/css/tii-icon-webfont.css');
+        $cssurl = moodle_url::make_pluginfile_url($contextid, 'mod_turnitintooltwo', 'direct', null, '/css/', 'tii-icon-webfont.css');
         $PAGE->requires->css($cssurl);
 
         // Include JS.


### PR DESCRIPTION
The files css, png, svg, woff and woff2 should be served through pluginfile.php to make Varnish caching easier (no need to re-configure Varnish).
The URLs in css files do not need to be changed if these css files are obtained via pluginfile.php because the URLs will be automatically replaced.
The patch adds a new file area 'direct' to only allow reading 'css','svg', 'png', 'woff' and 'woff2' file types.