### PR TITLE
Fixing broken unit tests

### DIFF
--- a/tests/unit/classes/digitalreceipt/instructor_message_test.php
+++ b/tests/unit/classes/digitalreceipt/instructor_message_test.php
@@ -27,7 +27,7 @@ class mod_turnitintooltwo_instructor_message_testcase extends advanced_testcase 
         ];
 
         $this->assertEquals(
-            'A submission entitled <strong>Foo</strong> has been made to assignment <strong>Bar</strong> in the class <strong>Foobar</strong>.<br /><br />Submission ID: <strong>1234567</strong><br />Submission Date: <strong>01-09-1994</strong><br />',
+            format_string('A submission entitled <strong>Foo</strong> has been made to assignment <strong>Bar</strong> in the class <strong>Foobar</strong>.<br /><br />Submission ID: <strong>1234567</strong><br />Submission Date: <strong>01-09-1994</strong><br />'),
             $instructormessage->build_instructor_message($data)
         );
     }
@@ -48,7 +48,7 @@ class mod_turnitintooltwo_instructor_message_testcase extends advanced_testcase 
         ];
 
         $this->assertEquals(
-            'A submission entitled <strong>Foo</strong> has been made to assignment <strong>Bar: Part 2</strong> in the class <strong>Foobar</strong>.<br /><br />Submission ID: <strong>1234567</strong><br />Submission Date: <strong>01-09-1994</strong><br />',
+            format_string('A submission entitled <strong>Foo</strong> has been made to assignment <strong>Bar: Part 2</strong> in the class <strong>Foobar</strong>.<br /><br />Submission ID: <strong>1234567</strong><br />Submission Date: <strong>01-09-1994</strong><br />'),
             $instructor_message->build_instructor_message($data)
         );
     }

--- a/tests/unit/classes/digitalreceipt/receipt_message_test.php
+++ b/tests/unit/classes/digitalreceipt/receipt_message_test.php
@@ -54,7 +54,7 @@ class mod_turnitintooltwo_receipt_message_testcase extends advanced_testcase {
 
         $response = $receipt_message->build_message($message);
 
-        $message_text = "Dear %s %s,<br /><br />You have successfully submitted the file <strong>%s</strong> to the assignment <strong>%s</strong> in the class <strong>%s</strong> on <strong>%s</strong>. Your submission id is <strong>%s</strong>. Your full digital receipt can be viewed and printed from the assignment inbox or from the print/download button in the document viewer.<br /><br />Thank you for using Turnitin,<br /><br />The Turnitin Team";
+        $message_text = format_string("Dear %s %s,<br /><br />You have successfully submitted the file <strong>%s</strong> to the assignment <strong>%s</strong> in the class <strong>%s</strong> on <strong>%s</strong>. Your submission id is <strong>%s</strong>. Your full digital receipt can be viewed and printed from the assignment inbox or from the print/download button in the document viewer.<br /><br />Thank you for using Turnitin,<br /><br />The Turnitin Team");
 
         $this->assertEquals(sprintf($message_text, $message['firstname'], $message['lastname'], $message['submission_title'], $message['assignment_name'], $message['course_fullname'], $date, $message['submission_id']) , $response);
     }
@@ -76,7 +76,7 @@ class mod_turnitintooltwo_receipt_message_testcase extends advanced_testcase {
 
         $response = $receipt_message->build_message($message);
 
-        $messagetext = "Dear %s %s,<br /><br />You have successfully submitted the file <strong>%s</strong> to the assignment <strong>%s: %s</strong> in the class <strong>%s</strong> on <strong>%s</strong>. Your submission id is <strong>%s</strong>. Your full digital receipt can be viewed and printed from the assignment inbox or from the print/download button in the document viewer.<br /><br />Thank you for using Turnitin,<br /><br />The Turnitin Team";
+        $messagetext = format_string("Dear %s %s,<br /><br />You have successfully submitted the file <strong>%s</strong> to the assignment <strong>%s: %s</strong> in the class <strong>%s</strong> on <strong>%s</strong>. Your submission id is <strong>%s</strong>. Your full digital receipt can be viewed and printed from the assignment inbox or from the print/download button in the document viewer.<br /><br />Thank you for using Turnitin,<br /><br />The Turnitin Team");
 
         $this->assertEquals(sprintf($messagetext, $message['firstname'], $message['lastname'],
             $message['submission_title'], $message['assignment_name'], $message['assignment_part'],

--- a/tests/unit/classes/v1migration/v1migration_test.php
+++ b/tests/unit/classes/v1migration/v1migration_test.php
@@ -268,7 +268,7 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
 
         // Test that assignment has been renamed.
         $updatedassignment = $DB->get_record('turnitintool', array('id' => $v1assignment->id));
-        $this->assertContains("(Migration in progress...)", $updatedassignment->name);
+        $this->assertStringContainsString("(Migration in progress...)", $updatedassignment->name);
 
         // Test that assignment has been hidden.
         $cm = get_coursemodule_from_instance('turnitintool', $v1assignment->id);
@@ -949,6 +949,6 @@ class mod_turnitintooltwo_v1migration_testcase extends test_lib {
         // Test that warning message is shown to user if they aren't allowed to edit migration tool status.
         $form = v1migration::output_settings_form(false);
 
-        $this->assertContains(get_string('migrationtoolaccounterror', 'turnitintooltwo'), $form);
+        $this->assertStringContainsString(get_string('migrationtoolaccounterror', 'turnitintooltwo'), $form);
     }
 }

--- a/tests/unit/classes/view/members_test.php
+++ b/tests/unit/classes/view/members_test.php
@@ -44,22 +44,22 @@ class mod_turnitintooltwo_view_members_testcase extends advanced_testcase {
         $actualmessage       = $members->build_intro_message();
         $expectedmessagetext = get_string('turnitinstudents_desc', 'turnitintooltwo');
 
-        $this->assertContains($expectedmessagetext, $actualmessage);
+        $this->assertStringContainsString($expectedmessagetext, $actualmessage);
 
         $actualmessage       = $members->build_intro_message("students");
         $expectedmessagetext = get_string("turnitinstudents_desc", "turnitintooltwo");
 
-        $this->assertContains($expectedmessagetext, $actualmessage);
+        $this->assertStringContainsString($expectedmessagetext, $actualmessage);
 
         $actualmessage       = $members->build_intro_message("foobar");
         $expectedmessagetext = get_string("turnitinstudents_desc", "turnitintooltwo");
 
-        $this->assertContains($expectedmessagetext, $actualmessage);
+        $this->assertStringContainsString($expectedmessagetext, $actualmessage);
 
         $actualmessage       = $members->build_intro_message("tutors");
         $expectedmessagetext = get_string("turnitintutors_desc", "turnitintooltwo");
 
-        $this->assertContains($expectedmessagetext, $actualmessage);
+        $this->assertStringContainsString($expectedmessagetext, $actualmessage);
     }
 
     /**

--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -52,7 +52,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
         $pageheading = 'Fake Heading';
         $turnitintooltwoview->output_header($pageurl, $pagetitle, $pageheading, true);
 
-        $this->assertContains($pageurl, (string)$PAGE->url);
+        $this->assertStringContainsString($pageurl, (string)$PAGE->url);
         $this->assertEquals($pagetitle, $PAGE->title);
         $this->assertEquals($pageheading, $PAGE->heading);
     }
@@ -78,7 +78,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 
         // Test that tab is present.
         $tabs = $turnitintooltwoview->draw_settings_menu('v1migration');
-        $this->assertContains(get_string('v1migrationtitle', 'turnitintooltwo'), $tabs);
+        $this->assertStringContainsString(get_string('v1migrationtitle', 'turnitintooltwo'), $tabs);
     }
 
     /**
@@ -99,7 +99,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
         }
 
         $tabs = $turnitintooltwoview->draw_settings_menu('v1migration');
-        $this->assertNotContains(get_string('v1migrationtitle', 'turnitintooltwo'), $tabs);
+        $this->assertStringNotContainsString(get_string('v1migrationtitle', 'turnitintooltwo'), $tabs);
 
         if (boolval($module)) {
             $tmpmodule->plugin = 'mod_turnitintool';
@@ -131,8 +131,8 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 		$turnitintooltwoview = new turnitintooltwo_view();
 		$table = $turnitintooltwoview->init_submission_inbox($cm, $turnitintooltwoassignment, $partdetails, $turnitintooltwouser);
 
-		$this->assertContains(get_string('studentlastname', 'turnitintooltwo'), $table, 'submission table did not contain expected text "'.get_string('studentlastname','turnitintooltwo').'"');
-		$this->assertContains("<tbody class=\"empty\"><tr><td colspan=\"16\"></td></tr></tbody>", $table, 'datatable did not contain the expected empty tbody');
+		$this->assertStringContainsString(get_string('studentlastname', 'turnitintooltwo'), $table, 'submission table did not contain expected text "'.get_string('studentlastname','turnitintooltwo').'"');
+		$this->assertStringContainsString("<tbody class=\"empty\"><tr><td colspan=\"16\"></td></tr></tbody>", $table, 'datatable did not contain the expected empty tbody');
 	}
 
 	public function test_inbox_table_structure_student() {
@@ -176,9 +176,9 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
 		reset($partdetails);
 		$partid = key($partdetails);
 
-		$this->assertNotContains(get_string('studentlastname', 'turnitintooltwo'), $table, 'submission table contained unexpected text "'.get_string('studentlastname','turnitintooltwo').'"');
-		$this->assertContains("<table class=\"mod_turnitintooltwo_submissions_data_table\" id=\"$partid\">", $table, 'Return did not include the expected table.');
-		$this->assertContains("<td class=\"centered_cell cell c0\" style=\"\">$partid</td>", $table, 'Return did not contain the expected student row.');
+		$this->assertStringNotContainsString(get_string('studentlastname', 'turnitintooltwo'), $table, 'submission table contained unexpected text "'.get_string('studentlastname','turnitintooltwo').'"');
+		$this->assertStringContainsString("<table class=\"mod_turnitintooltwo_submissions_data_table\" id=\"$partid\">", $table, 'Return did not include the expected table.');
+		$this->assertStringContainsString("<td class=\"centered_cell cell c0\" style=\"\">$partid</td>", $table, 'Return did not contain the expected student row.');
 	}
 
     /**

--- a/tests/unit/turnitintooltwo_assignment_test.php
+++ b/tests/unit/turnitintooltwo_assignment_test.php
@@ -55,9 +55,9 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 		$originaltitle = 'Test String is truncated and has a suffix added on the end with brackets showing the moodle coursetype';
 		$limit = 30;
 		$title = $turnitintooltwoassignment->truncate_title($originaltitle, $limit, 'TT');
-		$this->assertContains('Test String', $title);
-		$this->assertNotContains('added on the end', $title);
-		$this->assertContains('... (Moodle TT)', $title);
+		$this->assertStringContainsString('Test String', $title);
+		$this->assertStringNotContainsString('added on the end', $title);
+		$this->assertStringContainsString('... (Moodle TT)', $title);
 		$this->assertEquals($limit, strlen($title));
 	}
 
@@ -68,7 +68,7 @@ class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
 		$turnitintooltwo = new stdClass();
 		$turnitintooltwo->id = 1;
 
-		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);		
+		$turnitintooltwoassignment = new turnitintooltwo_assignment(0, $turnitintooltwo);
 		$turnitintooltwoassignment->set_checkbox_field('testvar1');
 
 		// Verify that checkbox fields are set to 0 by default.

--- a/tests/unit/turnitintooltwo_comms_test.php
+++ b/tests/unit/turnitintooltwo_comms_test.php
@@ -48,8 +48,8 @@ class mod_turnitintooltwo_comms_testcase extends advanced_testcase {
 		try {
 			throw new Exception("Throw a fake exception for testing.");
 		} catch(Exception $e) {
-		}		
-		
+		}
+
 		$turnitintooltwocomms = new turnitintooltwo_comms();
 		// Check error string with debugging set to developer level.
 		$CFG->debug = DEBUG_DEVELOPER;
@@ -57,13 +57,13 @@ class mod_turnitintooltwo_comms_testcase extends advanced_testcase {
 
 		// Error string should contain the file, line and the message.
 		if (is_callable(array($e, 'getFile'))) {
-			$this->assertContains($e->getFile(), $errorstring);
+			$this->assertStringContainsString($e->getFile(), $errorstring);
 		}
 		if (is_callable(array($e, 'getLine'))) {
-			$this->assertContains((string)$e->getLine(), $errorstring);
+			$this->assertStringContainsString((string)$e->getLine(), $errorstring);
 		}
 		if (is_callable(array($e, 'getMessage'))) {
-			$this->assertContains($e->getMessage(), $errorstring);
+			$this->assertStringContainsString($e->getMessage(), $errorstring);
 		}
 
 		// Check error string with debugging set to normal level.
@@ -72,13 +72,13 @@ class mod_turnitintooltwo_comms_testcase extends advanced_testcase {
 
 		// Error string should not contain the file and line, only the message.
 		if (is_callable(array($e, 'getFile'))) {
-			$this->assertNotContains($e->getFile(), $errorstring);
+			$this->assertStringNotContainsString($e->getFile(), $errorstring);
 		}
 		if (is_callable(array($e, 'getLine'))) {
-			$this->assertNotContains((string)$e->getLine(), $errorstring);
+			$this->assertStringNotContainsString((string)$e->getLine(), $errorstring);
 		}
 		if (is_callable(array($e, 'getMessage'))) {
-			$this->assertContains($e->getMessage(), $errorstring);
+			$this->assertStringContainsString($e->getMessage(), $errorstring);
 		}
 	}
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ if (empty($plugin)) {
     $plugin = new StdClass();
 }
 
-$plugin->version   = 2021060801;
+$plugin->version   = 2021101401;
 $plugin->release   = "3.1+";
 $plugin->requires  = 2016052300;
 $plugin->component = 'mod_turnitintooltwo';


### PR DESCRIPTION
Fixing unit tests that were broken as a result of a previously merged pul request. The tests also needed the string formatter. I have also changed the use of assertContains to the recommended alternative as that one was deprecated a long time ago.