### PR TITLE
Fix use of initially undefined variable when enrolling users to TII

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -622,7 +622,7 @@ class turnitintooltwo_assignment {
         $members = array_keys($students);
         foreach ($members as $member) {
             // Don't include user if they are suspended.
-            if (isset($suspendedusers[$user->id])) {
+            if (isset($suspendedusers[$member])) {
                 continue;
             }
             $user = new turnitintooltwo_user($member, "Learner");


### PR DESCRIPTION
Longstanding bug in apparently cargo-culted code to avoid enrolling suspended
users.

On first pass through loop variable 'user' is undefined; on subsequent passes it
holds erroneous value which may still have apparently-valid "id" attribute.
This may lead to users being incorrectly skipped as "suspended" on subsequent
loop iterations.

Also adds newline to end of file.