### PR TITLE
Fixes #634 Error when trying to restore

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -376,6 +376,8 @@ class turnitintooltwo_assignment {
                 $turnitincourse->id = $insertid;
             }
 
+            $coursetype = "TT";
+            $workflowcontext = "site";
             turnitintooltwo_activitylog("Class created - ".$turnitincourse->courseid." | ".$turnitincourse->turnitin_cid.
                                         " | ".$course->fullname . " (Moodle ".$coursetype.")" , "REQUEST");
 
@@ -410,6 +412,11 @@ class turnitintooltwo_assignment {
         // If a course end date is specified in Moodle then we set this in Turnitin with an additional month to
         // account for the Turnitin viewer becoming read-only once the class end date passes.
         if (!empty($course->enddate)) {
+            // The course end date must not be before the start date.
+            // Change the course end date if it is set earlier than today.
+            if ($course->enddate < strtotime('today')) {
+                $course->enddate = strtotime('today');
+            }
             $enddate = strtotime('+1 month', $course->enddate);
             $class->setEndDate(gmdate("Y-m-d\TH:i:s\Z", $enddate));
         }


### PR DESCRIPTION
The course end date must not be before the start date.
Change the course end date if it is set earlier than today.

When the course is being restored, if it contains a TII activity the request is compiled with the course end date from the backup. If the end date is in the past it will generate the error. I have modified the assignment class to change the date for this scenario.