### PR TITLE
Soap warning

### DIFF
--- a/sdk/soap.class.php
+++ b/sdk/soap.class.php
@@ -283,6 +283,7 @@ class Soap extends SoapClient {
         parent::__construct( $wsdl, $options );
     }
 
+    #[\ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = null) {
 
         $http_headers = array(


### PR DESCRIPTION
This fixes the

`Deprecated: Return type of Soap::__doRequest($request, $location, $action, $version, $one_way = null) should either be compatible with SoapClient::__doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in …/mod/turnitintooltwo/sdk/soap.class.php on line 286
`

warning under PHP 8.1.