### PR TITLE
INT-18633 supress warning with attribute flag

### DIFF
--- a/sdk/soap.class.php
+++ b/sdk/soap.class.php
@@ -282,7 +282,8 @@ class Soap extends SoapClient {
 
         parent::__construct( $wsdl, $options );
     }
-
+    
+    #[\ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = null) {
 
         $http_headers = array(


### PR DESCRIPTION
`ReturnTypeWillChange` hides warning in PHP 8.1 and is ignored as a comment in earlier versions.