### PR TITLE
Less strict checking of the expected title string in the page title

### DIFF
--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -53,7 +53,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
         $turnitintooltwoview->output_header($pageurl, $pagetitle, $pageheading, true);
 
         $this->assertStringContainsString($pageurl, (string)$PAGE->url);
-        $this->assertEquals($pagetitle, $PAGE->title);
+        $this->assertStringContainsString($pagetitle, $PAGE->title);
         $this->assertEquals($pageheading, $PAGE->heading);
     }
 


### PR DESCRIPTION
Since MDL-78806, the site name of the site is now being included in the page title of Moodle pages in order to improve the accessibility of page titles.

For more information, check out:
https://www.w3.org/WAI/WCAG21/Techniques/general/G88