### PR TITLE
fix: page title checks from exact match to contains match

### DIFF
--- a/tests/unit/classes/view/turnitintooltwo_view_test.php
+++ b/tests/unit/classes/view/turnitintooltwo_view_test.php
@@ -53,7 +53,7 @@ class mod_turnitintooltwo_view_testcase extends test_lib {
         $turnitintooltwoview->output_header($pageurl, $pagetitle, $pageheading, true);
 
         $this->assertStringContainsString($pageurl, (string)$PAGE->url);
-        $this->assertEquals($pagetitle, $PAGE->title);
+        $this->assertStringContainsString($pagetitle, $PAGE->title);
         $this->assertEquals($pageheading, $PAGE->heading);
     }
 


### PR DESCRIPTION
Resolves #694
