### PR TITLE
Replace icon-sml with icon

### DIFF
--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -1189,7 +1189,7 @@ class turnitintooltwo_view {
             $rawmodified = 1;
             $modified = html_writer::link($CFG->wwwroot."/mod/turnitintooltwo/view.php?id=".$cm->id."&action=manualsubmission".
                                             "&sub=".$submission->id.'&sesskey='.sesskey(),
-                                                $OUTPUT->pix_icon('icon-sml', get_string('submittoturnitin', 'turnitintooltwo'),
+                                                $OUTPUT->pix_icon('icon', get_string('submittoturnitin', 'turnitintooltwo'),
                                                     'mod_turnitintooltwo')." ".get_string('submittoturnitin', 'turnitintooltwo'));
 
         } else if (empty($submission->submission_objectid)) {


### PR DESCRIPTION
Submit to Turnitin icon wrongly requested as icon-sml and does not display on the page:
![image](https://github.com/turnitin/moodle-mod_turnitintooltwo/assets/73345838/deb64187-d43a-49e6-ac90-4864855d66d9)
Once changed to simply 'icon' the icon is once again visible.