### PR TITLE
Fix deprecated function usages

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -251,7 +251,7 @@ function turnitintooltwo_grade_item_update($turnitintooltwo, $grades = null) {
 
     // Get the latest part, for the post date and set the default hidden value on grade item.
     $lastpart = $DB->get_record('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id), 'max(dtpost)');
-    $lastpart = current($lastpart);
+    $lastpart = current((array)$lastpart);
     $params['hidden'] = $lastpart;
 
     // There should always be a $cm unless this is called on module creation.

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1852,20 +1852,21 @@ class turnitintooltwo_assignment {
         }
 
         foreach ($submissions as $submission) {
-            if (!is_nan($submission->submission_grade) AND (!empty($submission->submission_gmimaged) || $istutor)
-                    AND !is_null($submission->submission_grade) AND $weightarray[$submission->submission_part] != 0) {
+            if (isset($submission->submission_grade) && !is_nan($submission->submission_grade)
+                && (!empty($submission->submission_gmimaged) || $istutor)
+                && !is_null($submission->submission_grade) && $weightarray[$submission->submission_part] != 0) {
                 $weightedgrade = $submission->submission_grade / $weightarray[$submission->submission_part];
                 $overallgrade += $weightedgrade * ($weightarray[$submission->submission_part] / $overallweight) * $maxgrade;
             }
         }
 
-        if (!is_null($overallgrade) AND $this->turnitintooltwo->grade < 0) {
+        if (!is_null($overallgrade) && $this->turnitintooltwo->grade < 0) {
             return ($overallgrade == 0) ? 1 : ceil($overallgrade);
         } else {
             if (is_null($overallgrade)) {
                 return "--";
             }
-            return (!is_nan($overallgrade) AND !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
+            return (!is_nan($overallgrade) && !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
         }
     }
 


### PR DESCRIPTION
When debug messages are set to DEVELOPER the following issues will throw error messages:
- Applying current() to an object directly is now deprecated. Forcing type array before will solve this.
- Using null as a parameter for is_nan() is now deprecated. Checking if parameter is set before will solve this.