### PR TITLE
UCL_2024061800

### DIFF
--- a/backup/moodle2/restore_turnitintooltwo_stepslib.php
+++ b/backup/moodle2/restore_turnitintooltwo_stepslib.php
@@ -149,6 +149,7 @@ class restore_turnitintooltwo_activity_structure_step extends restore_activity_s
 
         // Create TII User Account Details.
         if (!$tiiuser = $DB->get_record('turnitintooltwo_users', array('turnitin_uid' => $data->tiiuserid))) {
+            $tiiuser = new stdClass();
             $tiiuser->userid = $data->userid;
             $tiiuser->turnitin_uid = $data->tiiuserid;
             $DB->insert_record('turnitintooltwo_users', $tiiuser);

--- a/db/access.php
+++ b/db/access.php
@@ -48,7 +48,7 @@ $capabilities = array(
 
     'mod/turnitintooltwo:submit' => array(
 
-        'captype' => 'write',
+        'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
         'legacy' => array(
             'student' => CAP_ALLOW
@@ -57,7 +57,7 @@ $capabilities = array(
 
     'mod/turnitintooltwo:grade' => array(
 
-        'captype' => 'write',
+        'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
         'legacy' => array(
             'teacher' => CAP_ALLOW,

--- a/lib.php
+++ b/lib.php
@@ -553,19 +553,27 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
  * @param string $datetype "start", "due" or "post" - Determines the kind of date we need to return.
  * @param object $part The assignment in which we need dates for.
  * @param int The counter used during the part creation.
- * @param stdClass $currentcourse - UCL - Added variable for course
+ * @param stdClass|null $currentcourse - UCL - Added variable for course
  * @return int A timestamp for the date we requested.
  */
-function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse) {
+function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse = null) {
     if ($renewdates) {
         switch ($datetype) {
             case 'start':
                 // UCL: Changed start date to use course start date, instead of current date.
-                return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
+                if (!is_null($currentcourse)) {
+                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
+                } else {
+                    return gmdate("Y-m-d\TH:i:s\Z", time());
+                }
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-               return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                if (!is_null($currentcourse)) {
+                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                } else {
+                    return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
+                }
             default:
                 return NULL;
         }

--- a/lib.php
+++ b/lib.php
@@ -493,9 +493,10 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
             $assignment->setEraterHandbook($eraterhandbook);
 
             // Generate the assignment dates depending on whether we are renewing them or not.
-            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i);
-            $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i);
-            $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i);
+            // UCL: Added in $currentcourse to turnitintooltwo_generate_part_dates() method,
+            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
+            $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
+            $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
 
             $assignment->setStartDate($datestart);
             $assignment->setDueDate($datedue);
@@ -552,16 +553,19 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
  * @param string $datetype "start", "due" or "post" - Determines the kind of date we need to return.
  * @param object $part The assignment in which we need dates for.
  * @param int The counter used during the part creation.
+ * @param stdClass $currentcourse - UCL - Added variable for course
  * @return int A timestamp for the date we requested.
  */
-function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i) {
+function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse) {
     if ($renewdates) {
         switch ($datetype) {
             case 'start':
-                return gmdate("Y-m-d\TH:i:s\Z", time());
+                // UCL: Changed start date to use course start date, instead of current date.
+                return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
             case 'due':
             case 'post':
-               return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
+                // UCL: Changed post/due dates to use course end date, instead of current date.
+               return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
             default:
                 return NULL;
         }

--- a/lib.php
+++ b/lib.php
@@ -251,7 +251,7 @@ function turnitintooltwo_grade_item_update($turnitintooltwo, $grades = null) {
 
     // Get the latest part, for the post date and set the default hidden value on grade item.
     $lastpart = $DB->get_record('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id), 'max(dtpost)');
-    $lastpart = current($lastpart);
+    $lastpart = current((array)$lastpart);
     $params['hidden'] = $lastpart;
 
     // There should always be a $cm unless this is called on module creation.

--- a/lib.php
+++ b/lib.php
@@ -569,7 +569,7 @@ function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, 
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-                if (!is_null($currentcourse)) {
+                if (!empty($currentcourse->enddate) && $currentcourse->enddate > time()) {
                     return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
                 } else {
                     return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));

--- a/lib.php
+++ b/lib.php
@@ -639,7 +639,7 @@ function turnitintooltwo_reset_course_form_definition(&$mform) {
     // Renew dates.
     $mform->addElement('checkbox', 'renew_assignment_dates', get_string('renew_assignment_dates', 'turnitintooltwo'));
     $mform->addHelpButton('renew_assignment_dates', 'renew_assignment_dates', 'turnitintooltwo');
-    $mform->setDefault('renew_assignment_dates', false);
+    $mform->setDefault('renew_assignment_dates', true);
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -846,7 +846,7 @@ function turnitintooltwo_cron_update_gradbook($assignment, $task) {
 }
 
 /**
- * Abstracted version of print_error()
+ * Abstracted version of throw new moodle_exception() - formerly print_error()
  *
  * @param string $input The error string if module = null otherwise the language string called by get_string()
  * @param string $module The module string
@@ -870,7 +870,7 @@ function turnitintooltwo_print_error($input, $module = 'turnitintooltwo',
         $message .= ' ('.basename($file).' | '.$line.')';
     }
 
-    print_error($input, 'turnitintooltwo', $link, $message);
+    throw new moodle_exception($input, 'turnitintooltwo', $link, $message);
     exit();
 }
 

--- a/lib.php
+++ b/lib.php
@@ -569,8 +569,19 @@ function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, 
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-                if (!empty($currentcourse->enddate) && $currentcourse->enddate > time()) {
-                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                if (!empty($currentcourse->startdate)) {
+                    if (!empty($currentcourse->enddate)) {
+                        // Using course end date
+                        $enddate = $currentcourse->enddate;
+                    } else {
+                        // Course end date is empty, add one week to start date
+                        $enddate = $currentcourse->startdate + (7 * 24 * 60 * 60);
+                    }
+                    // Make sure the end date used is in the future
+                    if ($enddate < time()) {
+                        $enddate = strtotime("+1 week");
+                    }
+                    return gmdate("Y-m-d\TH:i:s\Z", $enddate);
                 } else {
                     return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
                 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -34,7 +34,18 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
     private $turnitintooltwo;
 
     public function definition() {
-        global $DB, $USER, $COURSE;
+        global $DB, $USER, $COURSE, $PAGE;
+
+        // Don't do anything here if called from a completion page as output has already begun.
+        // This is needed because of MDL-78528.
+        $completionpagetypes = [
+            'course-defaultcompletion' => 'Edit completion default settings (Moodle >= 4.3)',
+            'course-editbulkcompletion' => 'Edit completion settings in bulk for a single course',
+            'course-editdefaultcompletion' => 'Edit completion default settings (Moodle < 4.3)',
+        ];
+        if (isset($completionpagetypes[$PAGE->pagetype])) {
+            return;
+        }
 
         // Module string is useful for product support.
         $modulestring = '<!-- Turnitin Moodle Direct Version: '.turnitintooltwo_get_version().' - (';
@@ -130,6 +141,15 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         $config = turnitintooltwo_admin_config();
 
         $mform =& $this->_form;
+
+        // Add in custom Javascript and CSS.
+        $PAGE->requires->jquery();
+        $PAGE->requires->jquery_plugin('ui');
+        $PAGE->requires->jquery_plugin('turnitintooltwo-turnitintooltwo', 'mod_turnitintooltwo');
+        $PAGE->requires->jquery_plugin('turnitintooltwo-colorbox', 'mod_turnitintooltwo');
+        $PAGE->requires->jquery_plugin('turnitintooltwo-moment', 'mod_turnitintooltwo');
+
+        $PAGE->requires->string_for_js('anonalert', 'turnitintooltwo');
 
         $script = html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
                                                         "href" => $CFG->wwwroot."/mod/turnitintooltwo/styles.css"));
@@ -612,7 +632,6 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         $features->groupmembersonly = true;
         $this->standard_coursemodule_elements($features);
         $this->add_action_buttons();
-
     }
 
     /**
@@ -711,4 +730,5 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
         return $current;
     }
+
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -131,15 +131,6 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
         $mform =& $this->_form;
 
-        // Add in custom Javascript and CSS.
-        $PAGE->requires->jquery();
-        $PAGE->requires->jquery_plugin('ui');
-        $PAGE->requires->jquery_plugin('turnitintooltwo-turnitintooltwo', 'mod_turnitintooltwo');
-        $PAGE->requires->jquery_plugin('turnitintooltwo-colorbox', 'mod_turnitintooltwo');
-        $PAGE->requires->jquery_plugin('turnitintooltwo-moment', 'mod_turnitintooltwo');
-
-        $PAGE->requires->string_for_js('anonalert', 'turnitintooltwo');
-
         $script = html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",
                                                         "href" => $CFG->wwwroot."/mod/turnitintooltwo/styles.css"));
         $script .= html_writer::tag('link', '', array("rel" => "stylesheet", "type" => "text/css",

--- a/mod_form.php
+++ b/mod_form.php
@@ -119,10 +119,10 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
         $modulestring .= ') -->';
 
-        $this->show_form($instructorrubrics, $sharedrubrics, $modulestring, $course->turnitin_cid);
+        $this->show_form($instructorrubrics, $sharedrubrics, $course->turnitin_cid, $modulestring);
     }
 
-    public function show_form($instructorrubrics, $sharedrubrics, $modulestring = '', $tiicourseid) {
+    public function show_form($instructorrubrics, $sharedrubrics, $tiicourseid, $modulestring = '') {
         global $CFG, $OUTPUT, $COURSE, $PAGE, $DB;
         $PAGE->requires->string_for_js('changerubricwarning', 'turnitintooltwo');
         $PAGE->requires->string_for_js('closebutton', 'turnitintooltwo');

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1854,20 +1854,21 @@ class turnitintooltwo_assignment {
         }
 
         foreach ($submissions as $submission) {
-            if (!is_nan($submission->submission_grade) AND (!empty($submission->submission_gmimaged) || $istutor)
-                    AND !is_null($submission->submission_grade) AND $weightarray[$submission->submission_part] != 0) {
+            if (isset($submission->submission_grade) && !is_nan($submission->submission_grade)
+                && (!empty($submission->submission_gmimaged) || $istutor)
+                && !is_null($submission->submission_grade) && $weightarray[$submission->submission_part] != 0) {
                 $weightedgrade = $submission->submission_grade / $weightarray[$submission->submission_part];
                 $overallgrade += $weightedgrade * ($weightarray[$submission->submission_part] / $overallweight) * $maxgrade;
             }
         }
 
-        if (!is_null($overallgrade) AND $this->turnitintooltwo->grade < 0) {
+        if (!is_null($overallgrade) && $this->turnitintooltwo->grade < 0) {
             return ($overallgrade == 0) ? 1 : ceil($overallgrade);
         } else {
             if (is_null($overallgrade)) {
                 return "--";
             }
-            return (!is_nan($overallgrade) AND !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
+            return (!is_nan($overallgrade) && !is_null($overallgrade)) ? number_format($overallgrade, 2) : '--';
         }
     }
 

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -377,7 +377,7 @@ class turnitintooltwo_assignment {
             }
 
             turnitintooltwo_activitylog("Class created - ".$turnitincourse->courseid." | ".$turnitincourse->turnitin_cid.
-                                        " | ".$course->fullname . " (Moodle ".$coursetype.")" , "REQUEST");
+                                        " | ".$course->fullname . " (Moodle TT)" , "REQUEST");
 
             return $turnitincourse;
         } catch (Exception $e) {

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -411,7 +411,9 @@ class turnitintooltwo_assignment {
         // account for the Turnitin viewer becoming read-only once the class end date passes.
         if (!empty($course->enddate)) {
             $enddate = strtotime('+1 month', $course->enddate);
-            $class->setEndDate(gmdate("Y-m-d\TH:i:s\Z", $enddate));
+            if ($enddate > time()) {
+                $class->setEndDate(gmdate("Y-m-d\TH:i:s\Z", $enddate));
+            }
         }
 
         try {

--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -1189,7 +1189,7 @@ class turnitintooltwo_view {
             $rawmodified = 1;
             $modified = html_writer::link($CFG->wwwroot."/mod/turnitintooltwo/view.php?id=".$cm->id."&action=manualsubmission".
                                             "&sub=".$submission->id.'&sesskey='.sesskey(),
-                                                $OUTPUT->pix_icon('icon-sml', get_string('submittoturnitin', 'turnitintooltwo'),
+                                                $OUTPUT->pix_icon('icon', get_string('submittoturnitin', 'turnitintooltwo'),
                                                     'mod_turnitintooltwo')." ".get_string('submittoturnitin', 'turnitintooltwo'));
 
         } else if (empty($submission->submission_objectid)) {

--- a/view.php
+++ b/view.php
@@ -97,6 +97,15 @@ require_login($course->id, true, $cm);
 $context = context_module::instance($cm->id);
 require_capability('mod/turnitintooltwo:view', $context);
 
+// Add in custom Javascript and CSS.
+$PAGE->requires->jquery();
+$PAGE->requires->jquery_plugin('ui');
+$PAGE->requires->jquery_plugin('turnitintooltwo-turnitintooltwo', 'mod_turnitintooltwo');
+$PAGE->requires->jquery_plugin('turnitintooltwo-colorbox', 'mod_turnitintooltwo');
+$PAGE->requires->jquery_plugin('turnitintooltwo-moment', 'mod_turnitintooltwo');
+
+$PAGE->requires->string_for_js('anonalert', 'turnitintooltwo');
+
 // Set the page layout to incourse - to make it full width.
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_cm($cm);

--- a/view.php
+++ b/view.php
@@ -97,15 +97,6 @@ require_login($course->id, true, $cm);
 $context = context_module::instance($cm->id);
 require_capability('mod/turnitintooltwo:view', $context);
 
-// Add in custom Javascript and CSS.
-$PAGE->requires->jquery();
-$PAGE->requires->jquery_plugin('ui');
-$PAGE->requires->jquery_plugin('turnitintooltwo-turnitintooltwo', 'mod_turnitintooltwo');
-$PAGE->requires->jquery_plugin('turnitintooltwo-colorbox', 'mod_turnitintooltwo');
-$PAGE->requires->jquery_plugin('turnitintooltwo-moment', 'mod_turnitintooltwo');
-
-$PAGE->requires->string_for_js('anonalert', 'turnitintooltwo');
-
 // Set the page layout to incourse - to make it full width.
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_cm($cm);


### PR DESCRIPTION
I have added two fixes for now deprecated function usages:
* current() now no longer accepts objects as parameters, so casting them into an array first fixes this.
* is_nan() no longer accepts null as a parameter. Checking if parameter is null before will fix this.

Maybe not merge but use this branch as the new default?
