### PR TITLE
Ensuring intro is saved in our db to facilitate assignment copy

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -751,7 +751,7 @@ class turnitintooltwo_assignment {
             $assignment->setDueDate(gmdate("Y-m-d\TH:i:s\Z", $this->turnitintooltwo->$attribute));
             $attribute = "dtpost".$i;
             $assignment->setFeedbackReleaseDate(gmdate("Y-m-d\TH:i:s\Z", $this->turnitintooltwo->$attribute));
-
+            $assignment->setInstructions(strip_tags($this->turnitintooltwo->intro));
             $assignment->setAuthorOriginalityAccess($this->turnitintooltwo->studentreports);
             $assignment->setRubricId((!empty($this->turnitintooltwo->rubric)) ? $this->turnitintooltwo->rubric : '');
             $assignment->setSubmitPapersTo($this->turnitintooltwo->submitpapersto);


### PR DESCRIPTION
Beforehand, we didn't copy the "intro" text into our db. This meant that if we wanted to copy a moodle V2 assignment to an LTI 1.3 assignment, the intro could never get copied because there was nothing in the db in the first place.

Part of https://turnitin.atlassian.net/browse/INT-20016