### PR TITLE
Rollover - set dates further into the future

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -553,19 +553,27 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
  * @param string $datetype "start", "due" or "post" - Determines the kind of date we need to return.
  * @param object $part The assignment in which we need dates for.
  * @param int The counter used during the part creation.
- * @param stdClass $currentcourse - UCL - Added variable for course
+ * @param stdClass|null $currentcourse - UCL - Added variable for course
  * @return int A timestamp for the date we requested.
  */
-function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse) {
+function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse = null) {
     if ($renewdates) {
         switch ($datetype) {
             case 'start':
                 // UCL: Changed start date to use course start date, instead of current date.
-                return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
+                if (!is_null($currentcourse)) {
+                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
+                } else {
+                    return gmdate("Y-m-d\TH:i:s\Z", time());
+                }
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-               return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                if (!is_null($currentcourse)) {
+                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                } else {
+                    return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
+                }
             default:
                 return NULL;
         }

--- a/lib.php
+++ b/lib.php
@@ -493,9 +493,10 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
             $assignment->setEraterHandbook($eraterhandbook);
 
             // Generate the assignment dates depending on whether we are renewing them or not.
-            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i);
-            $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i);
-            $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i);
+            // UCL: Added in $currentcourse to turnitintooltwo_generate_part_dates() method,
+            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
+            $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
+            $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
 
             $assignment->setStartDate($datestart);
             $assignment->setDueDate($datedue);
@@ -552,16 +553,19 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
  * @param string $datetype "start", "due" or "post" - Determines the kind of date we need to return.
  * @param object $part The assignment in which we need dates for.
  * @param int The counter used during the part creation.
+ * @param stdClass $currentcourse - UCL - Added variable for course
  * @return int A timestamp for the date we requested.
  */
-function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i) {
+function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, $currentcourse) {
     if ($renewdates) {
         switch ($datetype) {
             case 'start':
-                return gmdate("Y-m-d\TH:i:s\Z", time());
+                // UCL: Changed start date to use course start date, instead of current date.
+                return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->startdate);
             case 'due':
             case 'post':
-               return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
+                // UCL: Changed post/due dates to use course end date, instead of current date.
+               return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
             default:
                 return NULL;
         }

--- a/lib.php
+++ b/lib.php
@@ -569,7 +569,7 @@ function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, 
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-                if (!is_null($currentcourse)) {
+                if (!empty($currentcourse->enddate) && $currentcourse->enddate > time()) {
                     return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
                 } else {
                     return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));

--- a/lib.php
+++ b/lib.php
@@ -569,8 +569,19 @@ function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, 
             case 'due':
             case 'post':
                 // UCL: Changed post/due dates to use course end date, instead of current date.
-                if (!empty($currentcourse->enddate) && $currentcourse->enddate > time()) {
-                    return gmdate("Y-m-d\TH:i:s\Z", $currentcourse->enddate);
+                if (!empty($currentcourse->startdate)) {
+                    if (!empty($currentcourse->enddate)) {
+                        // Using course end date
+                        $enddate = $currentcourse->enddate;
+                    } else {
+                        // Course end date is empty, add one week to start date
+                        $enddate = $currentcourse->startdate + (7 * 24 * 60 * 60);
+                    }
+                    // Make sure the end date used is in the future
+                    if ($enddate < time()) {
+                        $enddate = strtotime("+1 week");
+                    }
+                    return gmdate("Y-m-d\TH:i:s\Z", $enddate);
                 } else {
                     return gmdate("Y-m-d\TH:i:s\Z", strtotime("+1 week"));
                 }

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -411,7 +411,9 @@ class turnitintooltwo_assignment {
         // account for the Turnitin viewer becoming read-only once the class end date passes.
         if (!empty($course->enddate)) {
             $enddate = strtotime('+1 month', $course->enddate);
-            $class->setEndDate(gmdate("Y-m-d\TH:i:s\Z", $enddate));
+            if ($enddate > time()) {
+                $class->setEndDate(gmdate("Y-m-d\TH:i:s\Z", $enddate));
+            }
         }
 
         try {


### PR DESCRIPTION
This one isn't maintenance related but a big hack that we've added because when rolling courses over (Moodle backup & restore) Turnitin defaults to setting the Post date to 2 weeks in the future. This sets the start date and post date to be much further into the future, relative to the new course start date. (this is the usual behaviour for activities with dates  in Moodle)

The reason this is a big deal is that when the post date passes Turnitin assignments with anonymous marking enabled get de-anonymised with no way back.
This ensures the date is far enough in the future / relatively accurately where the teachers will have enough time to prepare their courses and adjust these deadlines before encountering this issue.

can squash when merging.