### PR TITLE
CTP-2397 : now explicitely creating stdClass before assigning values

### DIFF
--- a/backup/moodle2/restore_turnitintooltwo_stepslib.php
+++ b/backup/moodle2/restore_turnitintooltwo_stepslib.php
@@ -149,6 +149,7 @@ class restore_turnitintooltwo_activity_structure_step extends restore_activity_s
 
         // Create TII User Account Details.
         if (!$tiiuser = $DB->get_record('turnitintooltwo_users', array('turnitin_uid' => $data->tiiuserid))) {
+            $tiiuser = new stdClass();
             $tiiuser->userid = $data->userid;
             $tiiuser->turnitin_uid = $data->tiiuserid;
             $DB->insert_record('turnitintooltwo_users', $tiiuser);


### PR DESCRIPTION
During restauration of a course containing a Turnitintooltwo module it causes an error due to the new strict type handling with PHP. Trying to assign an ID to a ‘false’ boolean (caused by a non-succesful SQL query) now fails. The variable needs to be redeclared as a stdClass before.

