### PR TITLE
forcing array type before using current()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1523,7 +1523,7 @@ function turnitintooltwo_init_browser_assignment_table($tiicourseid) {
                         );
 
     if (!empty($turnitincourse)) {
-        $course = current($turnitincourse);
+        $course = current((array)$turnitincourse);
         $coursedetails = turnitintooltwo_assignment::get_course_data($course->courseid, $course->course_type);
         $courseid = $course->courseid;
         $coursetitle = $coursedetails->fullname;


### PR DESCRIPTION
Applying current to an object is now deprecated.
Forcing type array before will solve this.

credit @opitz
rebased on develop from ucl-isd#9