### PR TITLE
Fix undefined variable $user

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -622,10 +622,10 @@ class turnitintooltwo_assignment {
         $members = array_keys($students);
         foreach ($members as $member) {
             // Don't include user if they are suspended.
+            $user = new turnitintooltwo_user($member, "Learner");
             if (isset($suspendedusers[$user->id])) {
                 continue;
             }
-            $user = new turnitintooltwo_user($member, "Learner");
             $user->join_user_to_class($course->turnitin_cid);
         }
         return true;


### PR DESCRIPTION
We are currently checking the value of a variable before it is assigned. This means that suspended users will not be excluded properly from course enrolment.