### PR TITLE
Replace deprecated coursecatlib.php

### DIFF
--- a/extras.php
+++ b/extras.php
@@ -97,15 +97,7 @@ switch ($cmd) {
 
         $output .= $OUTPUT->box($coursesearchform, 'generalbox', 'course_search_options');
 
-        $displaylist = array();
-        $parentlist = array();
-        require_once($CFG->dirroot."/course/lib.php");
-        if (file_exists($CFG->libdir.'/coursecatlib.php')) {
-            require_once($CFG->libdir.'/coursecatlib.php');
-            $displaylist = coursecat::make_categories_list('');
-        } else {
-            make_categories_list($displaylist, $parentlist, '');
-        }
+        $displaylist = core_course_category::make_categories_list('');
 
         $categoryselectlabel = html_writer::label(get_string('selectcoursecategory', 'turnitintooltwo'), 'create_course_category');
         $categoryselect = html_writer::select($displaylist, 'create_course_category', '', array(),

--- a/settings_extras.php
+++ b/settings_extras.php
@@ -328,7 +328,6 @@ switch ($cmd) {
         $output .= $OUTPUT->box($coursesearchform, 'generalbox', 'course_search_options');
 
         $displaylist = core_course_category::make_categories_list('');
-        $parentlist = array();
 
         $categoryselectlabel = html_writer::label(get_string('selectcoursecategory', 'turnitintooltwo'),
                                                     'create_course_category');


### PR DESCRIPTION
As of Moodle 3.6, coursecatlib is deprecated. This PR replaces our usage of coursecat::make_categories_list with core_course_category::make_categories_list