### PR TITLE
Fix division by zero error

### DIFF
--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -1294,7 +1294,7 @@ class turnitintooltwo_view {
                             .html_writer::tag('span', "/".$parts[$partid]->maxmarks,
                                     array("class" => "grademark_grade"));
                 } else if ($turnitintooltwoassignment->turnitintooltwo->gradedisplay == 1) { // 1 is percentage.
-                    $submissiongrade = (is_numeric($submissiongrade)) ? round($submissiongrade / $parts[$partid]->maxmarks * 100, 1).'%' : $submissiongrade;
+                    $submissiongrade = (is_numeric($submissiongrade) && $parts[$partid]->maxmarks > 0) ? round($submissiongrade / $parts[$partid]->maxmarks * 100, 1).'%' : $submissiongrade;
                     $grade .= html_writer::tag('span', $submissiongrade,
                                     array('class' => 'grade grademark_grade'));
                 }


### PR DESCRIPTION
When a part of an assignment has max grade of zero and we display the grade as a percentage, we get a division by zero error that results in an error 500. We need to check that maxmarks is greater than zero before doing the division. Otherwise, just show the submission grade instead of a percentage.