### PR TITLE
Respect allowed file types option

### DIFF
--- a/view.php
+++ b/view.php
@@ -159,8 +159,19 @@ $maxfilesize = get_user_max_upload_file_size($context,
                                                 $maxbytescourse,
                                                 $turnitintooltwoassignment->turnitintooltwo->maxfilesize);
 $maxfilesize = ($maxfilesize <= 0) ? TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE : $maxfilesize;
+
+
+if ($turnitintooltwoassignment->turnitintooltwo->allownonor) {
+  $acceptedtypes = ['*'];
+}
+else {
+  $acceptedtypes = ['doc', 'docx', 'wpd', 'html', 'htm', 'ps', 
+                    'txt', 'rtf', 'pdf', 'odt', 'hwp', 'hwpx', 
+                    'pptx'];
+}
 $turnitintooltwofileuploadoptions = array('maxbytes' => $maxfilesize,
-                                            'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => '*');
+                                            'subdirs' => false, 'maxfiles' => 1,
+                                            'accepted_types' => $acceptedtypes);
 
 if (!$parts = $turnitintooltwoassignment->get_parts()) {
     turnitintooltwo_print_error('partgeterror', 'turnitintooltwo', null, null, __FILE__, __LINE__);

--- a/view.php
+++ b/view.php
@@ -164,9 +164,9 @@ if ($turnitintooltwoassignment->turnitintooltwo->allownonor) {
   $acceptedtypes = ['*'];
 }
 else {
-  $acceptedtypes = ['doc', 'docx', 'wpd', 'html', 'htm', 'ps', 
-                    'txt', 'rtf', 'pdf', 'odt', 'hwp', 'hwpx', 
-                    'pptx'];
+  $acceptedtypes = ['.doc', '.docx', '.ppt', '.pptx', '.pps', '.ppsx',
+                    '.pdf', '.txt', '.htm', '.html', '.hwp', '.odt',
+                    '.wpd', '.ps', '.rtf', '.xls', '.xlsx'];
 }
 $turnitintooltwofileuploadoptions = ['maxbytes' => $maxfilesize,
                                      'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => $acceptedtypes];

--- a/view.php
+++ b/view.php
@@ -165,8 +165,8 @@ if ($turnitintooltwoassignment->turnitintooltwo->allownonor) {
 }
 else {
   $acceptedtypes = ['.doc', '.docx', '.ppt', '.pptx', '.pps', '.ppsx',
-                    '.pdf', '.txt', '.htm', '.html', '.hwp', '.odt',
-                    '.wpd', '.ps', '.rtf', '.xls', '.xlsx'];
+                    '.pdf', '.txt', '.htm', '.html', '.hwp', '.hwpx',
+                    '.odt', '.wpd', '.ps', '.rtf', '.xls', '.xlsx'];
 }
 $turnitintooltwofileuploadoptions = ['maxbytes' => $maxfilesize,
                                      'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => $acceptedtypes];

--- a/view.php
+++ b/view.php
@@ -160,7 +160,6 @@ $maxfilesize = get_user_max_upload_file_size($context,
                                                 $turnitintooltwoassignment->turnitintooltwo->maxfilesize);
 $maxfilesize = ($maxfilesize <= 0) ? TURNITINTOOLTWO_MAX_FILE_UPLOAD_SIZE : $maxfilesize;
 
-
 if ($turnitintooltwoassignment->turnitintooltwo->allownonor) {
   $acceptedtypes = ['*'];
 }
@@ -170,8 +169,7 @@ else {
                     'pptx'];
 }
 $turnitintooltwofileuploadoptions = array('maxbytes' => $maxfilesize,
-                                            'subdirs' => false, 'maxfiles' => 1,
-                                            'accepted_types' => $acceptedtypes);
+                                            'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => $acceptedtypes);
 
 if (!$parts = $turnitintooltwoassignment->get_parts()) {
     turnitintooltwo_print_error('partgeterror', 'turnitintooltwo', null, null, __FILE__, __LINE__);

--- a/view.php
+++ b/view.php
@@ -168,8 +168,8 @@ else {
                     'txt', 'rtf', 'pdf', 'odt', 'hwp', 'hwpx', 
                     'pptx'];
 }
-$turnitintooltwofileuploadoptions = array('maxbytes' => $maxfilesize,
-                                            'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => $acceptedtypes);
+$turnitintooltwofileuploadoptions = ['maxbytes' => $maxfilesize,
+                                     'subdirs' => false, 'maxfiles' => 1, 'accepted_types' => $acceptedtypes];
 
 if (!$parts = $turnitintooltwoassignment->get_parts()) {
     turnitintooltwo_print_error('partgeterror', 'turnitintooltwo', null, null, __FILE__, __LINE__);


### PR DESCRIPTION
Right now we don't respect the 'Allow Submission of Any File Type' option. We are currently allowing submission of any file type regardless of whether this option is set or not.

I have added a list of file types to accept based on this guide: https://guides.turnitin.com/hc/en-us/articles/23929463501965-File-requirements 

It is important that the list of accepted file extensions is accurate, so please could any reviewers check it and let me know if there are any that are wrong or any more I need to add.