### PR TITLE
Add return type for __doRequest

### DIFF
--- a/sdk/soap.class.php
+++ b/sdk/soap.class.php
@@ -283,8 +283,7 @@ class Soap extends SoapClient {
         parent::__construct( $wsdl, $options );
     }
     
-    #[\ReturnTypeWillChange]
-    public function __doRequest($request, $location, $action, $version, $one_way = null) {
+    public function __doRequest($request, $location, $action, $version, $one_way = null): ?string {
 
         $http_headers = array(
             'Content-type: text/xml;charset="utf-8"',


### PR DESCRIPTION
We are currently suppressing the missing return type warning for the function __doRequest. For good practice we should declare the return type explicitly instead.