### PR TITLE
Add null check in data dump

### DIFF
--- a/settings_extras.php
+++ b/settings_extras.php
@@ -111,7 +111,7 @@ switch ($cmd) {
                     $datarow = get_object_vars($datarow);
                     $output .= "|";
                     foreach ($datarow as $datacell) {
-                        $output .= ' '.htmlspecialchars(str_pad(substr($datacell, 0, $columnwidth), $columnwidth, " ", 1)).'|';
+                        $output .= ' '.htmlspecialchars(str_pad(substr($datacell ?? '', 0, $columnwidth), $columnwidth, " ", 1)).'|';
                     }
                     if ($table == 'turnitintooltwo_users' && $moodleusers[$datarow['userid']]) {
                         $firstname = format_string($moodleusers[$datarow['userid']]->firstname);


### PR DESCRIPTION
We are getting an error that prevents data dumps from being displayed and saved because newer PHP versions don't allow calling substr on a null string. Therefore we need a null check when displaying nullable values.