### PR TITLE
fix #779 fix #723 update default value for settings

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -115,11 +115,11 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configtext_int_only('turnitintooltwo/accountid',
                                                     get_string("turnitinaccountid", "turnitintooltwo"),
-                                                    get_string("turnitinaccountid_desc", "turnitintooltwo"), ''));
+                                                    get_string("turnitinaccountid_desc", "turnitintooltwo"), 0));
 
     $settings->add(new admin_setting_config_tii_secret_key('turnitintooltwo/secretkey',
                                                         get_string("turnitinsecretkey", "turnitintooltwo"),
-                                                        get_string("turnitinsecretkey_desc", "turnitintooltwo"), '', 'PARAM_TEXT'));
+                                                        get_string("turnitinsecretkey_desc", "turnitintooltwo"), ''));
 
     $testoptions = array(
         'https://api.turnitin.com' => 'https://api.turnitin.com',
@@ -137,7 +137,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('turnitintooltwo/apiurl',
                                     get_string("turnitinapiurl", "turnitintooltwo"),
                                     get_string("turnitinapiurl_desc", "turnitintooltwo").$offlinecomment.$testconnection,
-                                    0, $testoptions));
+                                    'https://api.turnitin.com', $testoptions));
 
     // Miscellaneous settings.
     $settings->add(new admin_setting_heading('turnitintooltwo_debugginglogs',

--- a/settingslib.php
+++ b/settingslib.php
@@ -78,7 +78,7 @@ class admin_setting_config_tii_secret_key extends admin_setting_configpasswordun
         }
 
         $cleaned = clean_param($data, $this->paramtype);
-        if ("$data" === "$cleaned" && strlen($data) > 0) { // Implicit conversion to string is needed to do exact comparison.
+        if ("$data" === "$cleaned") { // Implicit conversion to string is needed to do exact comparison.
             return true;
         } else {
             return get_string('validateerror', 'admin');


### PR DESCRIPTION
The default value need to match the type of the setting:

> `admin_setting_configtext_int_only` => the default value should be an INT
> `admin_setting_config_tii_secret_key` => This extends `admin_setting_configpasswordunmask` But this class doesn't have  param_type
>> The validate() method block the default value to be set to an empty string '' so an error is being raised. 
> `admin_setting_configselect` => Require a default value to be part of the option

In order to re-test the update, a PHP Unit reinitialize must be done.
