### PR TITLE
Fix logic for enable notify nonsubmitters

### DIFF
--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -2021,18 +2021,6 @@ class turnitintooltwo_view {
 
         $messageoutputs = get_config('message');
 
-        if ($CFG->branch >= 400) {
-            if (isset($messageoutputs->mod_turnitintooltwo_nonsubmitters_disable) && $messageoutputs->mod_turnitintooltwo_nonsubmitters_disable == "0") {
-                return true;
-            }
-        } else {
-            // Support for older versions.
-            foreach ($messageoutputs as $k => $v) {
-                if (strpos($k, '_mod_turnitintooltwo_nonsubmitters_loggedin') !== false) {
-                    return true;
-                }
-            }
-            return false;
-        }
+        return !isset($messageoutputs->mod_turnitintooltwo_nonsubmitters_disable) || $messageoutputs->mod_turnitintooltwo_nonsubmitters_disable == "0";
     }
 }


### PR DESCRIPTION
Our logic that checks for ability to notify nonsubmitters appears to have broken flow control, in versions past 4.0 it never returns false.
At this point we can also drop support for Moodle versions less than 4.0 so can cleanup some unused code there.