### PR TITLE
Delete old calendar events before creating new ones

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1790,3 +1790,21 @@ function turnitintooltwo_update_event($turnitintooltwo, $part, $courseparam = fa
         turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);
     }
 }
+
+
+/**
+ * Delete a Moodle event based on passed in details.
+ *
+ * @param  object  $turnitintooltwo    The turnitintooltwo assignment object.
+ * @param  object  $part               The name of the part we are deleting.
+ */
+function turnitintooltwo_delete_event($turnitintooltwo, $part) {
+  global $DB, $USER;
+
+  try {
+    $DB->delete_records_select("event", "modulename = ? AND userid = ? AND name = ?", 
+      [ "turnitintooltwo", $USER->id, $turnitintooltwo->name." - ".$part->partname ]);
+  } catch (Exception $e) {
+      turnitintooltwo_comms::handle_exceptions($e, 'turnitintooltwoupdateerror', false);
+  }
+}

--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1174,6 +1174,11 @@ class turnitintooltwo_assignment {
         $partdetails = $this->get_part_details($partid);
         $return["partid"] = $partid;
 
+        // Delete existing events for this assignment part if title or due date changed.
+        if ($fieldname == "partname" || $fieldname == "dtdue") {
+            turnitintooltwo_delete_event($this->turnitintooltwo, $partdetails);
+        }
+
         // Update Turnitin Assignment.
         $assignment = new TiiAssignment();
         $assignment->setAssignmentId($partdetails->tiiassignid);


### PR DESCRIPTION
We are currently creating duplicate events in the Moodle calendar when we change the name of a TT assignment part. This is because in our logic to update an existing calendar event we find the event using a sql query with the event name. Since the name has just been changed, we look for the event using the new name and fail to find it, so instead of updating the old record a new one is created. To fix this I delete the event before updating the name. After that the name is updated, the new event is created.
You may very well ask why we don't just store the ID of the event as a foreign key in the TT database table. To that I say good question. I agree this would be a better solution, but it would require adding database fields and would not be backward compatible when migrating plugin versions. Also it is possible to create additional events and link them to a TT assignment, further complicating things. Ideally a full rewrite of the way we handle events would be in order, but for now this will suffice to fix the bug we are seeing.