### PR TITLE
prevent passing NULL to strip_pluginfile_content().

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -860,7 +860,7 @@ class turnitintooltwo_assignment {
 
         $properties = new stdClass();
         $properties->name = $this->turnitintooltwo->name . ' - ' . $partname;
-        $intro = strip_pluginfile_content($this->turnitintooltwo->intro);
+        $intro = strip_pluginfile_content($this->turnitintooltwo->intro ?? '');
         $intro = preg_replace("/<img[^>]+\>/i", "", $intro);
         $properties->description = ($intro == null) ? '' : $intro;
         $properties->courseid = $this->turnitintooltwo->course;


### PR DESCRIPTION
passing NULL triggers are PHP deprecation warning when preg_replace() is called from within this core function.

fixes #793 