### PR TITLE
Renaming grademark / similarity dropdown headers

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -393,7 +393,7 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
             }
         }
 
-        $mform->addElement('header', 'advanced', get_string('turnitinoroptions', 'turnitintooltwo'));
+        $mform->addElement('header', 'similarityoptionsheader', get_string('turnitinoroptions', 'turnitintooltwo'));
 
         $mform->addElement('select', 'allowlate', get_string('allowlate', 'turnitintooltwo'), $ynoptions);
         $mform->setDefault('allowlate', $config->default_allowlate);
@@ -532,7 +532,7 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
 
         // Populate Rubric options.
         if (!empty($config->usegrademark)) {
-            $mform->addElement('header', 'advanced', get_string('turnitingmoptions', 'turnitintooltwo'));
+            $mform->addElement('header', 'grademarkoptionsheader', get_string('turnitingmoptions', 'turnitintooltwo'));
 
             // Add no rubric option and rubrics belonging to Instructor.
             $rubricoptions = array('' => get_string('norubric', 'turnitintooltwo')) + $instructorrubrics;


### PR DESCRIPTION
Currently opening the grademark options dropdown also opens the similarity options dropdown, and vice-versa. This PR renames the 2 headers so they will drop down separately.