### PR TITLE
If TFS request fails, setting submissions to empty list

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1585,6 +1585,10 @@ class turnitintooltwo_assignment {
         $turnitincomms = new turnitintooltwo_comms();
         $turnitincall = $turnitincomms->initialise_api();
 
+        if (empty($_SESSION["TiiSubmissions"][$part->id])) {
+            $_SESSION["TiiSubmissions"][$part->id] = [ ];
+        }
+
         try {
             $submission = new TiiSubmission();
             $submission->setAssignmentId($part->tiiassignid);


### PR DESCRIPTION
It's possible for the session variable tiisubmissions to be null if the call to TFS fails. Later code relies on this, so we should set a default value of an empty array.