### PR TITLE
Adding null check for transmatch

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1355,7 +1355,7 @@ class turnitintooltwo_assignment {
             $assignment->setSubmittedDocumentsCheck($this->turnitintooltwo->spapercheck);
             $assignment->setInternetCheck($this->turnitintooltwo->internetcheck);
             $assignment->setPublicationsCheck($this->turnitintooltwo->journalcheck);
-            $assignment->setTranslatedMatching($this->turnitintooltwo->transmatch);
+            $assignment->setTranslatedMatching($this->turnitintooltwo->transmatch ?? 0);
             $assignment->setAllowNonOrSubmissions($this->turnitintooltwo->allownonor);
 
             $attribute = "dtstart".$i;


### PR DESCRIPTION
When updating the rubric for an assignment, if the transmatch setting is not set we get an exception. This adds a default value.