### PR TITLE
Checking if formdata is set when handling error

### DIFF
--- a/view.php
+++ b/view.php
@@ -296,9 +296,11 @@ if (!empty($action)) {
 
             if ($error) {
                 // Save data in session incase of error.
-                $_SESSION['form_data']->submissiontype = $post['submissiontype'];
-                $_SESSION['form_data']->submissiontitle = $post['submissiontitle'];
-                $_SESSION['form_data']->submissiontext = $post['submissiontext'];
+                if (isset($_SESSION['form_data'])) {
+                    $_SESSION['form_data']->submissiontype = $post['submissiontype'];
+                    $_SESSION['form_data']->submissiontitle = $post['submissiontitle'];
+                    $_SESSION['form_data']->submissiontext = $post['submissiontext'];
+                }
             } else {
                 // Check for previous submission to this part.
                 if (!$prevsubmission = $turnitintooltwoassignment->get_user_submissions($post['studentsname'],


### PR DESCRIPTION
There's a suspected Moodle bug that allows submitting to a TT assignment when the disclaimer has not been agreed (Issue #799)
This was causing an exception due to the formdata session variable not being populated as we were expecting.
This PR adds a check which allows us to handle the error more gracefully.