### PR TITLE
Syncing description to TFS on Edit

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1336,6 +1336,8 @@ class turnitintooltwo_assignment {
             $assignment->setClassId($course->turnitin_cid);
             $assignment->setAuthorOriginalityAccess($this->turnitintooltwo->studentreports);
 
+            $assignment->setInstructions(strip_tags($this->turnitintooltwo->intro));
+
             $assignment->setRubricId((!empty($this->turnitintooltwo->rubric)) ? $this->turnitintooltwo->rubric : '');
             $assignment->setSubmitPapersTo($this->turnitintooltwo->submitpapersto);
             $assignment->setResubmissionRule($this->turnitintooltwo->reportgenspeed);


### PR DESCRIPTION
Currently the assignment intro/description/summary is only synced to turnitin when initially creating the assignment. This PR syncs the description when later updating it.