### PR TITLE
Refining check for character count

### DIFF
--- a/lang/en/turnitintooltwo.php
+++ b/lang/en/turnitintooltwo.php
@@ -66,6 +66,7 @@ $string['journalcheck_help'] = 'Check against the Turnitin journals, periodicals
 $string['maxfilesize'] = 'Maximum File Size';
 $string['maxfilesize_help'] = 'This setting determines the maximum file size for user submissions to each assignment part. The maximum value you can set this value to is dictated by the value set in course settings, this value is further capped to a maximum file size of 100Mb which is the maximum allowed filesize for file uploads to Turnitin.';
 $string['maxlength'] = 'The maximum length for {$a->field} is {$a->length} characters';
+$string['maxlengthwithinput'] = 'The maximum length for {$a->field} is {$a->length} characters. You input {$a->inputlength} characters.';
 $string['maxmarks'] = 'Max Marks';
 $string['pluginname'] = 'Turnitin Assignment 2';
 $string['modulename'] = 'Turnitin Assignment 2';

--- a/mod_form.php
+++ b/mod_form.php
@@ -605,8 +605,10 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         $formatparams = new stdClass();
         $formatparams->field = get_string('turnitintooltwointro', 'turnitintooltwo');
         $formatparams->length = TII_INTRO_CHARACTER_LIMIT;
-        if (strlen($data['introeditor']['text']) > TII_INTRO_CHARACTER_LIMIT) {
-            $errors['introeditor'] = get_string('maxlength', 'turnitintooltwo', $formatparams);
+        $formatparams->inputlength = mb_strlen(strip_tags($data['introeditor']['text']));
+
+        if ($formatparams->inputlength > TII_INTRO_CHARACTER_LIMIT) {
+            $errors['introeditor'] = get_string('maxlengthwithinput', 'turnitintooltwo', $formatparams);
         }
 
         foreach ($data as $name => $value) {


### PR DESCRIPTION
There's a discrepancy in how we count characters vs how Moodle does that sometimes allows extra chars to sneak through and break the call to TFS.
* Use `mb_strlen` instead of plain `strlen`. `strlen` counts the number of bytes in the string, whereas `mb_strlen` counts the number of utf-8 characters, so this resolves a potential discrepancy
* Use `strip_tags` to remove any html tags Moodle may have injected

Also added a new language string - translations for this will be added prior to release.