### PR TITLE
Type safe checking for number_format

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -790,9 +790,9 @@ function turnitintooltwo_cron_update_gradbook($assignment, $task) {
                 $overallgrade = $turnitintooltwoassignment->get_overall_grade($submissions, $cm);
                 if ($turnitintooltwoassignment->turnitintooltwo->grade < 0) {
                     // Using a scale.
-                    $grades->rawgrade = !is_numeric($overallgrade) ? null : (float)$overallgrade;
+                    $grades->rawgrade = is_numeric($overallgrade) ? (float)$overallgrade : null;
                 } else {
-                    $grades->rawgrade = !is_numeric($overallgrade) ? null : number_format((float)$overallgrade, 2);
+                    $grades->rawgrade = is_numeric($overallgrade) ? number_format((float)$overallgrade, 2) : null;
                 }
             }
             $grades->userid = $user->id;

--- a/lib.php
+++ b/lib.php
@@ -790,9 +790,9 @@ function turnitintooltwo_cron_update_gradbook($assignment, $task) {
                 $overallgrade = $turnitintooltwoassignment->get_overall_grade($submissions, $cm);
                 if ($turnitintooltwoassignment->turnitintooltwo->grade < 0) {
                     // Using a scale.
-                    $grades->rawgrade = ($overallgrade == '--') ? null : $overallgrade;
+                    $grades->rawgrade = !is_numeric($overallgrade) ? null : (float)$overallgrade;
                 } else {
-                    $grades->rawgrade = ($overallgrade == '--') ? null : number_format($overallgrade, 2);
+                    $grades->rawgrade = !is_numeric($overallgrade) ? null : number_format((float)$overallgrade, 2);
                 }
             }
             $grades->userid = $user->id;


### PR DESCRIPTION
If a TT assignment is graded using the Moodle gradebook with a letter grade, the grade will fail to sync back to the TT assignment as a string will be passed to the `number_format` function that can't be converted to a number. This PR adds type checking so that letter grades can be used.