### PR TITLE
call gradebook after weighting changed to update fraction

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -1196,6 +1196,14 @@ class turnitintooltwo_assignment {
                     $return["msg"] = get_string('maxmarkserror', 'turnitintooltwo');
                 } else {
                     $assignment->setMaxGrade($fieldvalue);
+                    // If we updated the max grade, the weighting will change, therefore update the gradebook
+                    $cm = get_coursemodule_from_instance("turnitintooltwo", $this->id,
+                        $assignment->turnitintooltwo->course);
+                    $submissions = $this->get_submissions($cm, $partid);
+                    $turnitintooltwosubmission = new turnitintooltwo_submission();
+                    foreach ($submissions[$partdetails->id] as $submission) {
+                        $turnitintooltwosubmission->update_gradebook($submission, $this);
+                    }
                 }
                 break;
 


### PR DESCRIPTION
When changing the 'Marks available' for a mod_turnitintooltwo activity after a user has already been graded, the updated grade from the submission is not pushed to the Moodle grade item. The original grade for that submission appears in the grader report instead. We now call the gradebook after updating the weightings.