### PR TITLE
Check max length for both introeditor and intro fields

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -610,10 +610,18 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
         $formatparams = new stdClass();
         $formatparams->field = get_string('turnitintooltwointro', 'turnitintooltwo');
         $formatparams->length = TII_INTRO_CHARACTER_LIMIT;
-        $formatparams->inputlength = mb_strlen(strip_tags($data['introeditor']['text']));
 
-        if ($formatparams->inputlength > TII_INTRO_CHARACTER_LIMIT) {
+        if (!empty($data['introeditor'])) {
+          $formatparams->inputlength = mb_strlen(strip_tags($data['introeditor']['text']));
+          if ($formatparams->inputlength > TII_INTRO_CHARACTER_LIMIT) {
             $errors['introeditor'] = get_string('maxlengthwithinput', 'turnitintooltwo', $formatparams);
+          }
+        }
+        else if (!empty($data['intro'])) {
+          $formatparams->inputlength = mb_strlen(strip_tags($data['intro']));
+          if ($formatparams->inputlength > TII_INTRO_CHARACTER_LIMIT) {
+            $errors['intro'] = get_string('maxlengthwithinput', 'turnitintooltwo', $formatparams);
+          }
         }
 
         foreach ($data as $name => $value) {


### PR DESCRIPTION
If the user is using Atto or TinyMCE the summary editor will be called `introeditor`, otherwise it will be called `intro`. We need to check both when checking the intro length.