### PR TITLE
Only clean intro if not empty

### DIFF
--- a/turnitintooltwo_assignment.class.php
+++ b/turnitintooltwo_assignment.class.php
@@ -838,8 +838,11 @@ class turnitintooltwo_assignment {
 
         $properties = new stdClass();
         $properties->name = $this->turnitintooltwo->name . ' - ' . $partname;
-        $intro = strip_pluginfile_content($this->turnitintooltwo->intro ?? '');
-        $intro = preg_replace("/<img[^>]+\>/i", "", $intro);
+        $intro = $this->turnitintooltwo->intro;
+        if (!empty($intro)) {
+            $intro = strip_pluginfile_content($intro);
+            $intro = preg_replace("/<img[^>]+\>/i", "", $intro);
+        }
         $properties->description = ($intro == null) ? '' : $intro;
         $properties->courseid = $this->turnitintooltwo->course;
         $properties->groupid = 0;


### PR DESCRIPTION
This is to resolve https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/833

Before:
```
1) mod_lib_testcase::test_turnitintooltwo_update_event
This test printed output: 
Deprecated: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/site/lib/weblib.php on line 1673
```

After:
```
root@567c0783abc4:/var/www/site# phpu --filter=mod_turnitintooltwo              
Moodle 4.1.5+ (Build: 20230908), 679d12a2f12f91a2d8d2726459e4e6966828b46a
Php: 8.1.2.1.2.13, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.1.0-1019-oem x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

..................................................                50 / 50 (100%)

Time: 00:03.617, Memory: 392.00 MB

OK (50 tests, 248 assertions)
```
