### PR TITLE
CTP-5509: Tidy PHPUnit tests

### DIFF
--- a/tests/unit/assignment_test.php
+++ b/tests/unit/assignment_test.php
@@ -22,6 +22,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use stdClass;
+use turnitintooltwo_assignment;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -32,7 +38,7 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/turnitintooltwo_assignment.cl
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_assignment_testcase extends advanced_testcase {
+class assignment_test extends advanced_testcase {
 
 	/**
 	 * Test that the title is truncated to the passed in limit.

--- a/tests/unit/classes/digitalreceipt/instructor_message_test.php
+++ b/tests/unit/classes/digitalreceipt/instructor_message_test.php
@@ -1,5 +1,10 @@
 <?php
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use instructor_message;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -10,7 +15,7 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/classes/digitalreceipt/instru
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_instructor_message_testcase extends advanced_testcase {
+class instructor_message_test extends advanced_testcase {
 
     /**
      * Test data being passed in will generate the correct output text.

--- a/tests/unit/classes/digitalreceipt/receipt_message_test.php
+++ b/tests/unit/classes/digitalreceipt/receipt_message_test.php
@@ -4,12 +4,17 @@
  * Unit tests for mod_turnitintooltwo classes/digitalreceipt/receipt_message
  */
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use receipt_message;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/mod/turnitintooltwo/classes/digitalreceipt/receipt_message.php');
 
-class mod_turnitintooltwo_receipt_message_testcase extends advanced_testcase {
+class receipt_message_test extends advanced_testcase {
 
     public function test_send_message() {
         global $DB;

--- a/tests/unit/classes/nonsubmitters/nonsubmitters_message_test.php
+++ b/tests/unit/classes/nonsubmitters/nonsubmitters_message_test.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -10,7 +14,7 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/classes/nonsubmitters/nonsubm
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_nonsubmitter_message_testcase extends advanced_testcase {
+class nonsubmitters_message_test extends advanced_testcase {
 
     /**
      * Test that non submitter messages send.
@@ -21,7 +25,7 @@ class mod_turnitintooltwo_nonsubmitter_message_testcase extends advanced_testcas
 
         $sink = $this->redirectMessages();
 
-        $nonsubmitters_message = new nonsubmitters_message();
+        $nonsubmitters_message = new \nonsubmitters_message();
 
         // Generate two new users to send messages to.
         $user1 = $this->getDataGenerator()->create_user();

--- a/tests/unit/classes/privacy/provider_test.php
+++ b/tests/unit/classes/privacy/provider_test.php
@@ -22,8 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_turnitintooltwo;
+
+use context_module;
 use core_privacy\local\metadata\collection;
-use core_privacy\local\request\deletion_criteria;
 use mod_turnitintooltwo\privacy\provider;
 
 defined('MOODLE_INTERNAL') || die();
@@ -36,7 +38,7 @@ if (!class_exists('\core_privacy\tests\provider_testcase')) {
     return;
 }
 
-class mod_turnitintooltwo_privacy_provider_testcase extends \core_privacy\tests\provider_testcase {
+class provider_test extends \core_privacy\tests\provider_testcase {
 
     private $testcase;
     private $turnitintooltwoassignment;
@@ -51,7 +53,7 @@ class mod_turnitintooltwo_privacy_provider_testcase extends \core_privacy\tests\
 
         $this->resetAfterTest();
 
-        $this->testcase = new mod_lib_testcase();
+        $this->testcase = new lib_test();
         $generator = $this->getDataGenerator();
 
         // Set up test assignment.

--- a/tests/unit/classes/v1migration/v1migration_test.php
+++ b/tests/unit/classes/v1migration/v1migration_test.php
@@ -14,6 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_turnitintooltwo;
+
+use core\output\html_writer;
+use Countable;
+use moodle_url;
+use stdClass;
+use test_lib;
+use v1migration;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -26,7 +35,7 @@ require_once($CFG->libdir . "/gradelib.php");
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_v1migration_testcase extends test_lib {
+class v1migration_test extends test_lib {
 
     /** Workaround for new php.7.2 warning
      * see http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types

--- a/tests/unit/classes/view/members_test.php
+++ b/tests/unit/classes/view/members_test.php
@@ -1,5 +1,12 @@
 <?php
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use members_view;
+use turnitintooltwo_assignment;
+use turnitintooltwo_view;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -14,7 +21,7 @@ require_once($CFG->dirroot . '/mod/lti/lib.php');
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_view_members_testcase extends advanced_testcase {
+class members_test extends advanced_testcase {
     /**
      * Test display role given returns as the expected Turnitin role
      */

--- a/tests/unit/classes/view/view_test.php
+++ b/tests/unit/classes/view/view_test.php
@@ -22,6 +22,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_turnitintooltwo;
+
+use stdClass;
+use test_lib;
+use turnitintooltwo_view;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -38,7 +44,7 @@ require_once($CFG->dirroot . '/course/lib.php');
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_view_testcase extends test_lib {
+class view_test extends test_lib {
 
     /**
      * Test that the page layout is set to standard so that the header displays.

--- a/tests/unit/comms_test.php
+++ b/tests/unit/comms_test.php
@@ -22,6 +22,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use Exception;
+use turnitintooltwo_comms;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -32,7 +38,7 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/turnitintooltwo_comms.class.p
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_comms_testcase extends advanced_testcase {
+class comms_test extends advanced_testcase {
 
 	public function test_handle_exceptions() {
 		global $CFG;

--- a/tests/unit/lib_test.php
+++ b/tests/unit/lib_test.php
@@ -1,5 +1,13 @@
 <?php
 
+namespace mod_turnitintooltwo;
+
+use context_module;
+use stdClass;
+use test_lib;
+use turnitintooltwo_assignment;
+use v1migration;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -15,7 +23,7 @@ require_once($CFG->dirroot . '/mod/turnitintooltwo/turnitintooltwo_assignment.cl
  *
  * @package turnitintooltwo
  */
-class mod_lib_testcase extends test_lib {
+class lib_test extends test_lib {
     /**
      * Test that we have the correct course type.
      */
@@ -76,7 +84,7 @@ class mod_lib_testcase extends test_lib {
 
         global $DB;
 
-        $v1migrationtest = new mod_turnitintooltwo_v1migration_testcase();
+        $v1migrationtest = new \mod_turnitintooltwo\v1migration_test();
 
         if (!$v1migrationtest->v1installed()) {
             return false;
@@ -129,7 +137,7 @@ class mod_lib_testcase extends test_lib {
 
         global $DB;
 
-        $v1migrationtest = new mod_turnitintooltwo_v1migration_testcase();
+        $v1migrationtest = new \mod_turnitintooltwo\v1migration_test();
 
         if (!$v1migrationtest->v1installed()) {
             return false;

--- a/tests/unit/mod_form_test.php
+++ b/tests/unit/mod_form_test.php
@@ -22,7 +22,13 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace mod_turnitintooltwo;
+
 global $CFG;
+
+use advanced_testcase;
+use mod_turnitintooltwo_mod_form;
+use stdClass;
 
 require_once($CFG->dirroot . '/mod/turnitintooltwo/mod_form.php');
 

--- a/tests/unit/submission_test.php
+++ b/tests/unit/submission_test.php
@@ -1,5 +1,12 @@
 <?php
 
+namespace mod_turnitintooltwo;
+
+use advanced_testcase;
+use stdClass;
+use turnitintooltwo_assignment;
+use turnitintooltwo_submission;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -16,7 +23,7 @@ require_once($CFG->dirroot . '/course/lib.php');
  *
  * @package turnitintooltwo
  */
-class mod_turnitintooltwo_submission_testcase extends advanced_testcase {
+class submission_test extends advanced_testcase {
     /**
      * Test create submission function returns the expected bollean given a data array.
      */


### PR DESCRIPTION
Align phpunit filenames and classnames and namespace classes.
Fixes issues in more recent versions of PHPUnit and when running the tests using paratest