### PR TITLE
LMS assignment copy assignment creation error

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -470,7 +470,7 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
 
             // Generate the assignment dates depending on whether we are renewing them or not.
             // Always use current time for copied assignments to avoid Turnitin rejecting very old start dates.
-            $datestart = gmdate("Y-m-d\TH:i:s\Z", time());
+            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
             $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
             $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
 
@@ -566,6 +566,23 @@ function turnitintooltwo_generate_part_dates($renewdates, $datetype, $part, $i, 
         }
     } else {
         $attribute = "dt".$datetype.$i;
+
+        // If the course is older than 1 year ago, but user doesn't want to renew the dates of the course, Turnitin will reject the assignment.
+        // To prevent this, set the assignment start date to now.
+        if (!empty($part->$attribute) && $part->$attribute < strtotime('-1 year')) {
+            $now = time();
+            switch ($datetype) {
+                case 'start':
+                    return gmdate("Y-m-d\TH:i:s\Z", $now);
+                case 'due':
+                    return gmdate("Y-m-d\TH:i:s\Z", strtotime('+7 days', $now));
+                case 'post':
+                    return gmdate("Y-m-d\TH:i:s\Z", strtotime('+7 days', $now));
+                default:
+                    return NULL;
+            }
+        }
+
         return gmdate("Y-m-d\TH:i:s\Z", $part->$attribute);
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -469,8 +469,8 @@ function turnitintooltwo_duplicate_recycle($courseid, $action, $renewdates = nul
             $assignment->setAllowNonOrSubmissions($turnitintooltwoassignment->turnitintooltwo->allownonor);
 
             // Generate the assignment dates depending on whether we are renewing them or not.
-            // UCL: Added in $currentcourse to turnitintooltwo_generate_part_dates() method,
-            $datestart = turnitintooltwo_generate_part_dates($renewdates, "start", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
+            // Always use current time for copied assignments to avoid Turnitin rejecting very old start dates.
+            $datestart = gmdate("Y-m-d\TH:i:s\Z", time());
             $datedue   = turnitintooltwo_generate_part_dates($renewdates, "due", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
             $datepost  = turnitintooltwo_generate_part_dates($renewdates, "post", $turnitintooltwoassignment->turnitintooltwo, $i, $currentcourse);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized change to date generation during course reset/copy; may shift due dates for very old copied assignments when users opt not to renew dates.
> 
> **Overview**
> Fixes **LMS assignment copy** failures when Turnitin rejects assignments whose stored start/due/post dates are too far in the past.
> 
> When course reset/recycle runs **without** “renew assignment dates”, `turnitintooltwo_generate_part_dates()` now detects part dates older than one year and substitutes **start = now**, **due/post = now + 7 days** instead of sending the original timestamps to Turnitin. The comment above date generation in `turnitintooltwo_duplicate_recycle()` was updated to describe this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df033ff29fd12632231283245b42b764fc8d9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->