### PR TITLE
Remove call to htmlentities when saving title

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -288,6 +288,8 @@ function turnitintooltwo_update_instance($turnitintooltwo) {
 function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
+    $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
+
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {
         $id = $turnitintooltwoassignment->create_moodle_assignment();

--- a/lib.php
+++ b/lib.php
@@ -288,8 +288,6 @@ function turnitintooltwo_update_instance($turnitintooltwo) {
 function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
-    $turnitintooltwo->name = htmlentities($turnitintooltwo->name);
-
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {
         $id = $turnitintooltwoassignment->create_moodle_assignment();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line sanitization change for activity names only; no auth or data-model changes.
> 
> **Overview**
> When creating or updating a Turnitin activity, **`turnitintooltwo_edit_instance`** now sanitizes the activity **name** with **`strip_tags()`** instead of **`htmlentities()`**.
> 
> That stops titles from being stored with HTML entity encoding (e.g. `&amp;` in the database) and instead keeps plain text with markup removed, which matches how Moodle usually handles activity names and how this plugin already treats other strings (e.g. temp filenames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4681f7f900f849fd27c17ca3e2df3def8f72cdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->