### PR TITLE
Merge to QA

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -288,6 +288,8 @@ function turnitintooltwo_update_instance($turnitintooltwo) {
 function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
+    $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
+
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {
         $id = $turnitintooltwoassignment->create_moodle_assignment();

--- a/lib.php
+++ b/lib.php
@@ -288,8 +288,6 @@ function turnitintooltwo_update_instance($turnitintooltwo) {
 function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
-    $turnitintooltwo->name = htmlentities($turnitintooltwo->name);
-
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {
         $id = $turnitintooltwoassignment->create_moodle_assignment();

--- a/lib.php
+++ b/lib.php
@@ -289,6 +289,9 @@ function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
     $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
+    if (empty($turnitintooltwo->name)) {
+        $turnitintooltwo->name = 'Turnitin V2 Assignment';
+    }
 
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {

--- a/lib.php
+++ b/lib.php
@@ -289,7 +289,7 @@ function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
     $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
-    if (empty($turnitintooltwo->name)) {
+    if (strlen($turnitintooltwo->name) === 0) {
         $turnitintooltwo->name = 'Turnitin V2 Assignment';
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field sanitization on add/update instance only; no auth, grading, or submission flow changes.
> 
> **Overview**
> **Assignment name handling** in `turnitintooltwo_edit_instance` (used when creating or updating a Turnitin V2 activity) no longer runs the title through `htmlentities()`. Names are now passed through `strip_tags()` so markup is removed instead of entity-encoded into the stored/display name.
> 
> If stripping leaves an empty string, the name is set to the default **`Turnitin V2 Assignment`** so create/update still has a non-empty title for Moodle and Turnitin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c186b086a797ab5b3543c6c1c44e8be0c505f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->