### PR TITLE
Add check for missing title after stripping tags

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -289,6 +289,9 @@ function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
     $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
+    if (empty($turnitintooltwo->name)) {
+        $turnitintooltwo->name = 'Turnitin V2 Assignment';
+    }
 
     $turnitintooltwoassignment = new turnitintooltwo_assignment($id, $turnitintooltwo);
     if ($id == 0) {

--- a/lib.php
+++ b/lib.php
@@ -289,7 +289,7 @@ function turnitintooltwo_edit_instance($id, $turnitintooltwo) {
     global $USER;
 
     $turnitintooltwo->name = strip_tags($turnitintooltwo->name);
-    if (empty($turnitintooltwo->name)) {
+    if (strlen($turnitintooltwo->name) === 0) {
         $turnitintooltwo->name = 'Turnitin V2 Assignment';
     }
 


### PR DESCRIPTION
If the title is set to just `<hello>` for example, the assignment will be saved with a blank name, leading to undefined behaviour. The assignment will not be visible on the Course page, and the course will fail to open with an error such as: `Course cache integrity check failed: course module with id x does not have context. Rebuilding cache for course y`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in shared edit logic; reduces broken course-module state with no auth or data-model changes.
> 
> **Overview**
> After **HTML tags are stripped** from the activity title in `turnitintooltwo_edit_instance`, an empty result (e.g. a title that was only markup like `<hello>`) is replaced with the fallback **`Turnitin V2 Assignment`** before create/update runs.
> 
> This applies to both **new** and **updated** Turnitin V2 activities, since add and update both go through the same edit path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62ae609d77e0376eeda146769204850d8cb4906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->