### PR TITLE
INT-24975 No wrap pencil icon for assignment inbox

### DIFF
--- a/turnitintooltwo_view.class.php
+++ b/turnitintooltwo_view.class.php
@@ -715,7 +715,7 @@ class turnitintooltwo_view {
         if ($istutor) {
             $textfield = html_writer::link('#', $partdetails[$partid]->partname.html_writer::tag('i', '', array('class' => 'fa fa-pencil fa-lg grey editor-pencil')),
                                             array('title' => get_string('edit', 'turnitintooltwo'),
-                                                'class' => 'edit_part editable_text editable_text_'.$partid,
+                                                'class' => 'edit_part editable_text editable_text_'.$partid.' nowrap',
                                                 'data-type' => 'text', 'data-pk' => $partid, 'data-name' => 'partname',
                                                 'id' => 'part_name_'.$partid,
                                                 'data-params' => "{ 'assignment': ".
@@ -730,7 +730,7 @@ class turnitintooltwo_view {
         if ($istutor) {
             $datefield = html_writer::link('#', $datefield.html_writer::tag('i', '', array('class' => 'fa fa-pencil fa-lg grey editor-pencil')),
                                             array('title' => get_string('edit', 'turnitintooltwo'),
-                                                'class' => 'edit_start_date editable_date editable_date_'.$partid,
+                                                'class' => 'edit_start_date editable_date editable_date_'.$partid.' nowrap',
                                                 'data-pk' => $partid, 'data-name' => 'dtstart', 'id' => 'date_start_'.$partid,
                                                 'data-params' => "{ 'assignment': ".
                                                                     $turnitintooltwoassignment->turnitintooltwo->id.", ".
@@ -746,7 +746,7 @@ class turnitintooltwo_view {
             $datefield = html_writer::link('#', $datefield.html_writer::tag('i', '', array('class' => 'fa fa-pencil fa-lg grey editor-pencil')),
                                             array('data-anon' => $turnitintooltwoassignment->turnitintooltwo->anon,
                                                 'title' => get_string('edit', 'turnitintooltwo'),
-                                                'class' => 'editable_postdue editable_date editable_date_'.$partid,
+                                                'class' => 'editable_postdue editable_date editable_date_'.$partid.' nowrap',
                                                 'data-pk' => $partid, 'data-name' => 'dtdue', 'id' => 'date_due_'.$partid,
                                                 'data-params' => "{ 'assignment': ".
                                                                     $turnitintooltwoassignment->turnitintooltwo->id.", ".
@@ -764,7 +764,7 @@ class turnitintooltwo_view {
                                                 'data-unanon' => $partdetails[$partid]->unanon,
                                                 'data-submitted' => $partdetails[$partid]->submitted,
                                                 'title' => get_string('edit', 'turnitintooltwo'),
-                                                'class' => 'editable_postdue editable_date editable_date_'.$partid,
+                                                'class' => 'editable_postdue editable_date editable_date_'.$partid.' nowrap',
                                                 'data-pk' => $partid, 'data-name' => 'dtpost', 'id' => 'date_post_'.$partid,
                                                 'data-params' => "{ 'assignment': ".
                                                                     $turnitintooltwoassignment->turnitintooltwo->id.", ".
@@ -799,7 +799,7 @@ class turnitintooltwo_view {
             if ($istutor) {
                 $textfield = html_writer::link('#', $partdetails[$partid]->maxmarks.html_writer::tag('i', '', array('class' => 'fa fa-pencil fa-lg grey editor-pencil')),
                                                 array('title' => get_string('edit', 'turnitintooltwo'),
-                                                    'class' => 'editable_text editable_text_'.$partid . ' ' . $class, 'id' => 'marks_'.$partid,
+                                                    'class' => 'editable_text editable_text_'.$partid . ' ' . $class . ' nowrap', 'id' => 'marks_'.$partid,
                                                     'data-type' => 'text', 'data-pk' => $partid, 'data-name' => 'maxmarks',
                                                     'data-params' => "{ 'assignment': ".
                                                                         $turnitintooltwoassignment->turnitintooltwo->id.", ".


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only class additions on inbox part-detail links; no logic, API, or permission changes.
> 
> **Overview**
> Fixes layout in the **submission inbox part details** table (INT-24975) so tutor inline-edit controls stay on one line with their values.
> 
> In `get_submission_inbox_part_details`, the PR appends the **`nowrap`** CSS class to the `html_writer::link` elements for editable **part name**, **start/due/post dates**, and **max marks** (alongside existing `editable_text` / `editable_date` classes). That keeps each label/date/marks value and its **pencil** icon from breaking onto separate lines in narrow table cells. No change to edit behavior, data attributes, or permissions—markup/class strings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaa49cd9cedd0b303a64c11551f3b64946c778a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->