### PR TITLE
5.3 -  FEATURE_GROUPMEMBERSONLY constant has been deprecated

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -112,7 +112,6 @@ function turnitintooltwo_supports($feature) {
     defined("FEATURE_SHOW_DESCRIPTION") or define("FEATURE_SHOW_DESCRIPTION", null);
     switch($feature) {
         case FEATURE_GROUPS:
-        case FEATURE_GROUPMEMBERSONLY:
         case FEATURE_MOD_INTRO:
         case FEATURE_COMPLETION_TRACKS_VIEWS:
         case FEATURE_GRADE_HAS_GRADE:


### PR DESCRIPTION
The FEATURE_GROUPMEMBERSONLY constant has been deprecated and is no longer supported. It should be removed from any plugin code.

For more information see MDL-83231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line removal of a deprecated Moodle constant with no change to grading, submissions, or other supported features.
> 
> **Overview**
> Aligns the Turnitin V2 activity with **Moodle 5.3** (MDL-83231) by dropping the deprecated `FEATURE_GROUPMEMBERSONLY` case from `turnitintooltwo_supports()` in `lib.php`.
> 
> Group support via `FEATURE_GROUPS` is unchanged; only the obsolete group-members-only feature flag is no longer advertised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4a79248d2e1390ba9dcfe93851c48e4bb578de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->