### PR TITLE
v2026072801 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+### Date:       2026-July-28
+### Release:    v2026072801
+
+---
+
+#### Submission List Ordering Update for Anonymous Assignments
+When anonymous marking is enabled, new submissions will now be ordered correctly in the submission inbox.
+
+#### Document Viewer Respects 'Do Not Refresh' Setting
+An issue was fixed where the document viewer did not respect the 'Do not refresh' setting.
+
+#### Assignment Copy Start Date Handling Improved
+When using Moodle assignment copy, the assignment start date is no longer copied to the new assignment. This prevents Turnitin from rejecting copied assignments that have very old start dates.
+
+#### UI Fixes
+Several user interface improvements and visual fixes were made.
+
+---
+
 ### Date:       2025-December-11
 ### Release:    v2025121101
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ if (empty($plugin)) {
     $plugin = new StdClass();
 }
 
-$plugin->version   = 2025121101;
+$plugin->version   = 2026072801;
 $plugin->release   = "4.5+";
 $plugin->requires  = 2024100700; // Require Moodle 4.5.0+
 $plugin->component = 'mod_turnitintooltwo';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release metadata only in this PR (version and changelog); no application logic changes in the diff.
> 
> **Overview**
> This PR **bumps the plugin version** to `2026072801` in `version.php` and **documents release v2026072801** in `CHANGELOG.md`.
> 
> The changelog entry describes fixes and improvements shipped in this release (not introduced by this diff itself): **correct submission inbox ordering when anonymous marking is enabled**, the **document viewer honoring the “Do not refresh” setting**, **Moodle assignment copy no longer copying start dates** (avoiding Turnitin rejections on very old dates), and **miscellaneous UI fixes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dedcff8a0bf9002a19937b135e96c8d8f23bfd40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->