### PR TITLE
INT-24980 Release to QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+### Date:       2026-July-28
+### Release:    v2026072801
+
+---
+
+#### Submission List Ordering Update for Anonymous Assignments
+When anonymous marking is enabled, new submissions will now be ordered correctly in the submission inbox.
+
+#### Document Viewer Respects 'Do Not Refresh' Setting
+An issue was fixed where the document viewer did not respect the 'Do not refresh' setting.
+
+#### Assignment Copy Start Date Handling Improved
+When using Moodle assignment copy, the assignment start date is no longer copied to the new assignment. This prevents Turnitin from rejecting copied assignments that have very old start dates.
+
+#### UI Fixes
+Several user interface improvements and visual fixes were made.
+
+---
+
 ### Date:       2025-December-11
 ### Release:    v2025121101
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ if (empty($plugin)) {
     $plugin = new StdClass();
 }
 
-$plugin->version   = 2025121101;
+$plugin->version   = 2026072801;
 $plugin->release   = "4.5+";
 $plugin->requires  = 2024100700; // Require Moodle 4.5.0+
 $plugin->component = 'mod_turnitintooltwo';


### PR DESCRIPTION
Contains release version: v2026072801

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog only in this PR; no application logic changes. Risk depends on code already merged for the listed fixes, not on these metadata updates.
> 
> **Overview**
> **Release packaging** for **v2026072801**: bumps `mod_turnitintooltwo` plugin version in `version.php` from `2025121101` to `2026072801` and adds the corresponding **CHANGELOG** entry for 2026-July-28.
> 
> The changelog documents what ships in this release (implementation is not in this diff): **anonymous assignment** submission inbox ordering, **document viewer** honoring **do not refresh**, **Moodle assignment copy** no longer copying start dates (avoids Turnitin rejections on old dates), and assorted **UI** fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ddd963055707e725dcfe4a81dd82942cbc9081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->